### PR TITLE
Snapshot diff: raw-diff option

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
 	github.com/go-logr/logr v1.2.3
+	github.com/hexops/gotextdiff v1.0.3
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/onsi/ginkgo/v2 v2.1.6
 	github.com/onsi/gomega v1.20.1

--- a/go.sum
+++ b/go.sum
@@ -524,6 +524,8 @@ github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2p
 github.com/hashicorp/memberlist v0.2.2/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hashicorp/serf v0.9.5/go.mod h1:UWDWwZeL5cuWDJdl0C6wrvrUwEqtQ4ZKBKKENpqIUyk=
+github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
+github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.0.0/go.mod h1:4qWG/gcEcfX4z/mBDHJ++3ReCw9ibxbsNJbcucJdbSo=
 github.com/huandu/xstrings v1.2.0/go.mod h1:DvyZB1rfVYsBIigL8HwpZgxHwXozlTgGqn63UyNX5k4=

--- a/internal/commands/snapshot/export_test.go
+++ b/internal/commands/snapshot/export_test.go
@@ -35,4 +35,5 @@ var (
 	RollbackClusters                = rollbackClusters
 	RollbackClusterProfile          = rollbackClusterProfile
 	RollbackConfigurationToSnapshot = rollbackConfigurationToSnapshot
+	GetResourceFromResourceOwner    = getResourceFromResourceOwner
 )

--- a/internal/commands/snapshot/rollback_test.go
+++ b/internal/commands/snapshot/rollback_test.go
@@ -368,7 +368,7 @@ var _ = Describe("Snapshot Rollback", func() {
 		name := randomString()
 		namespace := randomString()
 
-		configMap, err := getUnstructured([]byte(fmt.Sprintf(configMapWithPolicy, namespace, name)))
+		configMap, err := GetUnstructured([]byte(fmt.Sprintf(configMapWithPolicy, namespace, name)))
 		Expect(err).To(BeNil())
 		Expect(snapshotter.DumpObject(configMap, folder, klogr.New())).To(Succeed())
 
@@ -391,7 +391,7 @@ var _ = Describe("Snapshot Rollback", func() {
 
 		name := randomString()
 
-		clusterProfile, err := getUnstructured([]byte(fmt.Sprintf(clusterProfileTemplate, name)))
+		clusterProfile, err := GetUnstructured([]byte(fmt.Sprintf(clusterProfileTemplate, name)))
 		Expect(err).To(BeNil())
 		Expect(snapshotter.DumpObject(clusterProfile, folder, klogr.New())).To(Succeed())
 
@@ -505,8 +505,8 @@ func createDirectoryWithObjects(snapshotName, snapshotStorage string, objects []
 	return snapshotDir
 }
 
-// getUnstructured returns an unstructured given a []bytes containing it
-func getUnstructured(object []byte) (*unstructured.Unstructured, error) {
+// GetUnstructured returns an unstructured given a []bytes containing it
+func GetUnstructured(object []byte) (*unstructured.Unstructured, error) {
 	request := &unstructured.Unstructured{}
 
 	universalDeserializer := kubectlscheme.Codecs.UniversalDeserializer()

--- a/internal/commands/snapshot/snapshot_suite_test.go
+++ b/internal/commands/snapshot/snapshot_suite_test.go
@@ -26,6 +26,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2/klogr"
 	"sigs.k8s.io/cluster-api/util"
@@ -85,6 +86,11 @@ func randomString() string {
 
 func addTypeInformationToObject(obj client.Object) error {
 	scheme, err := utils.GetScheme()
+	if err != nil {
+		return err
+	}
+	// Following are needed by test only
+	err = rbacv1.AddToScheme(scheme)
 	if err != nil {
 		return err
 	}

--- a/internal/commands/snapshot_reconciler.go
+++ b/internal/commands/snapshot_reconciler.go
@@ -64,9 +64,11 @@ func SnapshotReconciler(ctx context.Context, req reconcile.Request) (reconcile.R
 func reconcileDelete(ctx context.Context, snapshotInstance *utilsv1alpha1.Snapshot,
 	logger logr.Logger) (reconcile.Result, error) {
 
+	logger.V(logs.LogInfo).Info("reconcileDelete")
 	snapshotClient := snapshotter.GetClient()
 	err := snapshotClient.CleanupEntries(snapshotInstance)
 	if err != nil {
+		logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to cleanup: %s", err))
 		return ctrl.Result{}, err
 	}
 
@@ -85,9 +87,11 @@ func reconcileDelete(ctx context.Context, snapshotInstance *utilsv1alpha1.Snapsh
 func reconcileNormal(ctx context.Context, snapshotInstance *utilsv1alpha1.Snapshot,
 	logger logr.Logger) (reconcile.Result, error) {
 
+	logger.V(logs.LogInfo).Info("reconcileNormal")
 	accessInstance := utils.GetAccessInstance()
 	if !controllerutil.ContainsFinalizer(snapshotInstance, utilsv1alpha1.SnapshotFinalizer) {
 		if err := addFinalizer(ctx, snapshotInstance); err != nil {
+			logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to add finalizer: %s", err))
 			return reconcile.Result{}, err
 		}
 	}

--- a/internal/snapshotter/client.go
+++ b/internal/snapshotter/client.go
@@ -200,7 +200,7 @@ func (d *deployer) GetNamespacedResources(snapshotFolder, kind string, logger lo
 	for i := range files {
 		if files[i].IsDir() {
 			namespaceDirectory := filepath.Join(snapshotFolder, files[i].Name())
-			r, err := getResourcesForKind(namespaceDirectory, kind, logger)
+			r, err := d.getResourcesForKind(namespaceDirectory, kind, logger)
 			if err != nil {
 				return nil, err
 			}
@@ -238,10 +238,10 @@ func (d *deployer) GetClusterResources(snapshotFolder, kind string, logger logr.
 		return nil, fmt.Errorf("%s", msg)
 	}
 
-	return getResourcesForKind(snapshotFolder, kind, logger)
+	return d.getResourcesForKind(snapshotFolder, kind, logger)
 }
 
-func getResourcesForKind(directory, kind string, logger logr.Logger) ([]*unstructured.Unstructured, error) {
+func (d *deployer) getResourcesForKind(directory, kind string, logger logr.Logger) ([]*unstructured.Unstructured, error) {
 	// Each directory, contains one subdirectory per Kind
 	// For instance /<whatever>/<snapshotInstanceName>/<dateSnaphostTaken>/<namespaceName>/<kindName>
 	// within such directory there all resources of that type found at the time snapshot was taken
@@ -273,7 +273,7 @@ func getResourcesForKind(directory, kind string, logger logr.Logger) ([]*unstruc
 		if err != nil {
 			return nil, err
 		}
-		u, err := getUnstructured(content)
+		u, err := d.GetUnstructured(content)
 		if err != nil {
 			return nil, err
 		}
@@ -284,8 +284,8 @@ func getResourcesForKind(directory, kind string, logger logr.Logger) ([]*unstruc
 	return result, nil
 }
 
-// getUnstructured returns an unstructured given a []bytes containing it
-func getUnstructured(object []byte) (*unstructured.Unstructured, error) {
+// GetUnstructured returns an unstructured given a []bytes containing it
+func (d *deployer) GetUnstructured(object []byte) (*unstructured.Unstructured, error) {
 	request := &unstructured.Unstructured{}
 	universalDeserializer := scheme.Codecs.UniversalDeserializer()
 	_, _, err := universalDeserializer.Decode(object, nil, request)

--- a/internal/snapshotter/client_test.go
+++ b/internal/snapshotter/client_test.go
@@ -236,8 +236,9 @@ var _ = Describe("Client", func() {
 		Expect(os.IsNotExist(err)).To(BeTrue())
 	})
 
-	It("getUnstructured returns unstructured", func() {
-		u, err := snapshotter.GetUnstructured([]byte(clusterConfigurationInstance))
+	It("GetUnstructured returns unstructured", func() {
+		instance := snapshotter.GetClient()
+		u, err := instance.GetUnstructured([]byte(clusterConfigurationInstance))
 		Expect(err).To(BeNil())
 		Expect(u).ToNot(BeNil())
 		Expect(u.GetKind()).To(Equal(configv1alpha1.ClusterConfigurationKind))
@@ -255,7 +256,8 @@ var _ = Describe("Client", func() {
 		for i := range files {
 			namespaceFolder := filepath.Join(snapshotFolder, files[i].Name())
 			By(fmt.Sprintf("finding resources in folder %s", namespaceFolder))
-			list, err := snapshotter.GetResourcesForKind(namespaceFolder, configv1alpha1.ClusterConfigurationKind, klogr.New())
+			instance := snapshotter.GetClient()
+			list, err := snapshotter.GetResourcesForKind(instance, namespaceFolder, configv1alpha1.ClusterConfigurationKind, klogr.New())
 			Expect(err).To(BeNil())
 			Expect(list).ToNot(BeNil())
 			Expect(len(list)).ToNot(BeZero())
@@ -272,7 +274,8 @@ var _ = Describe("Client", func() {
 		Expect(len(files)).ToNot(BeZero())
 
 		By(fmt.Sprintf("finding resources in folder %s", snapshotFolder))
-		list, err := snapshotter.GetResourcesForKind(snapshotFolder, configv1alpha1.ClusterProfileKind, klogr.New())
+		instance := snapshotter.GetClient()
+		list, err := snapshotter.GetResourcesForKind(instance, snapshotFolder, configv1alpha1.ClusterProfileKind, klogr.New())
 		Expect(err).To(BeNil())
 		Expect(list).ToNot(BeNil())
 		Expect(len(list)).ToNot(BeZero())

--- a/internal/snapshotter/export_test.go
+++ b/internal/snapshotter/export_test.go
@@ -23,8 +23,7 @@ var (
 	ProcessRequests  = processRequests
 	CollectSnapshot  = collectSnapshot
 
-	GetUnstructured            = getUnstructured
-	GetResourcesForKind        = getResourcesForKind
+	GetResourcesForKind        = (*deployer).getResourcesForKind
 	AddTypeInformationToObject = addTypeInformationToObject
 )
 

--- a/internal/snapshotter/worker_test.go
+++ b/internal/snapshotter/worker_test.go
@@ -232,7 +232,8 @@ func recursiveSearchDir(dir string, objects map[string]bool) {
 		} else {
 			content, err := os.ReadFile(path.Join(dir, files[i].Name()))
 			Expect(err).To(BeNil())
-			u, err := snapshotter.GetUnstructured(content)
+			instance := snapshotter.GetClient()
+			u, err := instance.GetUnstructured(content)
 			Expect(err).To(BeNil())
 			objects[objectToString(u)] = true
 		}

--- a/k8s/sveltosctl.yaml
+++ b/k8s/sveltosctl.yaml
@@ -106,6 +106,13 @@ rules:
       - get
       - list
       - watch
+      - update
+  - apiGroups: ["utils.projectsveltos.io"]
+    resources:
+    - snapshots/finalizers
+    verbs:
+    - patch
+    - update      
   - apiGroups: ["utils.projectsveltos.io"]
     resources:
       - snapshots/status


### PR DESCRIPTION
raw-diff option, if selected, display diff in features deployed in a cluster.

```
kubectl exec -it -n projectsveltos sveltosctl-0 -- ./sveltosctl snapshot diff --snapshot=hourly --from-sample=2022-10-11:19:28:00 --to-sample=2022-10-11:19:30:00 --raw-diff

--- kyverno.io/ClusterPolicy no-gateway from /snapshot/hourly/2022-10-11:19:28:00
+++ kyverno.io/ClusterPolicy no-gateway from /snapshot/hourly/2022-10-11:19:30:00
@@ -3,7 +3,7 @@
 metadata:
   name: no-gateway
   annotations:
-    policies.kyverno.io/title: Block Create,Update,Delete of Gateway instances
+    policies.kyverno.io/title: Block updates of Gateway instances
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Gateway
     policies.kyverno.io/description: >-
```