### PR TITLE
Add show usage command

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,25 @@ Usage:
      --clusterprofile=<name> Show features deployed because of this clusterprofile. If not specified all clusterprofile names are considered.
 ```
 
+## Display usage
+
+show usage displays following information:
+1. which CAPI clusters are currently a match for a ClusterProfile
+2. for ConfigMap/Secret referenced by at least by ClusterProfile, in which CAPI clusters their content is currently deployed.
+
+Such information is useful to see what CAPI clusters would be affected by a change before making such a change.
+
+```
+./bin/sveltosctl show usage 
++----------------+--------------------+----------------------------+-------------------------------------+
+| RESOURCE KIND  | RESOURCE NAMESPACE |       RESOURCE NAME        |              CLUSTERS               |
++----------------+--------------------+----------------------------+-------------------------------------+
+| ClusterProfile |                    | mgianluc                   | default/sveltos-management-workload |
+| ConfigMap      | default            | kyverno-disallow-gateway-2 | default/sveltos-management-workload |
++----------------+--------------------+----------------------------+-------------------------------------+
+```
+
+
 ## Display outcome of ClusterProfile's in DryRun mode
 
 A ClusterProfile can be set in DryRun mode. While in DryRun mode, nothing gets deployed/withdrawn to/from matching CAPI clusters. A report is instead generated listing what would happen if ClusterProfile sync mode would be changed from DryRun to Continuous.

--- a/internal/commands/show.go
+++ b/internal/commands/show.go
@@ -36,6 +36,7 @@ func Show(ctx context.Context, args []string, logger logr.Logger) error {
   sveltosctl show [options] <subcommand> [<args>...]
 
     features      Displays information on policies (resources and helm releases) deployed in clusters.
+    usage         Displays information on which CAPI clusters will be affected by a policy (ClusterProfile or referenced ConfigMaps/Secrets) change.
     dryrun        Displays information on ClusterProfiles in DryRun mode. It displays what changes would
                   take effect if a ClusterProfile were to be moved out of DryRun mode.
 
@@ -73,6 +74,8 @@ See 'sveltosctl show <subcommand> --help' to read about a specific subcommand.
 			err = show.Features(ctx, arguments, logger)
 		case "dryrun":
 			err = show.DryRun(ctx, arguments, logger)
+		case "usage":
+			err = show.Usage(ctx, arguments, logger)
 		default:
 			//nolint: forbidigo // print doc
 			fmt.Println(doc)

--- a/internal/commands/show/export_test.go
+++ b/internal/commands/show/export_test.go
@@ -19,4 +19,5 @@ package show
 var (
 	DisplayFeatures = displayFeatures
 	DisplayDryRun   = displayDryRun
+	ShowUsage       = showUsage
 )

--- a/internal/commands/show/usage.go
+++ b/internal/commands/show/usage.go
@@ -1,0 +1,293 @@
+/*
+Copyright 2022. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package show
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/docopt/docopt-go"
+	"github.com/go-logr/logr"
+	"github.com/olekukonko/tablewriter"
+
+	configv1alpha1 "github.com/projectsveltos/cluster-api-feature-manager/api/v1alpha1"
+	"github.com/projectsveltos/sveltosctl/internal/logs"
+	"github.com/projectsveltos/sveltosctl/internal/utils"
+)
+
+var (
+	// resourceKind indentifies the type of resource (ClusterProfile, ConfigMap, Secret)
+	// resourceNamespace and resourceName is the kubernetes resource namespace/name
+	// clusters is the list of clusters where resource content is deployed
+	genUsageRow = func(resourceKind, resourceNamespace, resourceName string, clusters []string,
+	) []string {
+		return []string{
+			resourceKind,
+			resourceNamespace,
+			resourceName,
+			strings.Join(clusters, "\n"),
+		}
+	}
+)
+
+func showUsage(ctx context.Context, kind, passedNamespace, passedName string, logger logr.Logger) error {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"RESOURCE KIND", "RESOURCE NAMESPACE", "RESOURCE NAME", "CLUSTERS"})
+
+	if kind == "" || kind == configv1alpha1.ClusterProfileKind {
+		if err := showUsageForClusterProfiles(ctx, passedName, table, logger); err != nil {
+			return err
+		}
+	}
+	if kind == "" || kind == string(configv1alpha1.ConfigMapReferencedResourceKind) {
+		if err := showUsageForConfigMaps(ctx, passedNamespace, passedName, table, logger); err != nil {
+			return err
+		}
+	}
+	if kind == "" || kind == string(configv1alpha1.SecretReferencedResourceKind) {
+		if err := showUsageForSecrets(ctx, passedNamespace, passedName, table, logger); err != nil {
+			return err
+		}
+	}
+
+	table.Render()
+
+	return nil
+}
+
+func showUsageForClusterProfiles(ctx context.Context, passedName string, table *tablewriter.Table, logger logr.Logger) error {
+	instance := utils.GetAccessInstance()
+
+	cps, err := instance.ListClusterProfiles(ctx, logger)
+	if err != nil {
+		return err
+	}
+
+	for i := range cps.Items {
+		cp := &cps.Items[i]
+		if passedName == "" || cp.Name == passedName {
+			showUsageForClusterProfile(cp, table, logger)
+		}
+	}
+
+	return nil
+}
+
+func getMatchingClusters(clusterProfile *configv1alpha1.ClusterProfile) []string {
+	clusters := make([]string, len(clusterProfile.Status.MatchingClusterRefs))
+	for i := range clusterProfile.Status.MatchingClusterRefs {
+		c := &clusterProfile.Status.MatchingClusterRefs[i]
+		clusters[i] = fmt.Sprintf("%s/%s", c.Namespace, c.Name)
+	}
+	return clusters
+}
+
+func showUsageForClusterProfile(clusterProfile *configv1alpha1.ClusterProfile, table *tablewriter.Table, logger logr.Logger) {
+	logger.V(logs.LogVerbose).Info(fmt.Sprintf("Considering ClusterProfile %s", clusterProfile.Name))
+
+	clusters := getMatchingClusters(clusterProfile)
+
+	table.Append(genUsageRow(configv1alpha1.ClusterProfileKind, "", clusterProfile.Name, clusters))
+}
+
+func showUsageForConfigMaps(ctx context.Context, passedNamespace, passedName string,
+	table *tablewriter.Table, logger logr.Logger) error {
+
+	instance := utils.GetAccessInstance()
+
+	cps, err := instance.ListClusterProfiles(ctx, logger)
+	if err != nil {
+		return err
+	}
+
+	result := make(map[configv1alpha1.PolicyRef][]string)
+
+	for i := range cps.Items {
+		cp := &cps.Items[i]
+		logger.V(logs.LogVerbose).Info(fmt.Sprintf("Collect referenced ConfigMaps from ClusterProfile %s", cp.Name))
+		getConfigMaps(passedNamespace, passedName, cp, result, logger)
+	}
+
+	for pr := range result {
+		table.Append(genUsageRow(string(configv1alpha1.ConfigMapReferencedResourceKind),
+			pr.Namespace, pr.Name, result[pr]))
+	}
+
+	return nil
+}
+
+func showUsageForSecrets(ctx context.Context, passedNamespace, passedName string,
+	table *tablewriter.Table, logger logr.Logger) error {
+
+	instance := utils.GetAccessInstance()
+
+	cps, err := instance.ListClusterProfiles(ctx, logger)
+	if err != nil {
+		return err
+	}
+
+	result := make(map[configv1alpha1.PolicyRef][]string)
+
+	for i := range cps.Items {
+		cp := &cps.Items[i]
+		logger.V(logs.LogVerbose).Info(fmt.Sprintf("Collect referenced Secret from ClusterProfile %s", cp.Name))
+		getSecrets(passedNamespace, passedName, cp, result, logger)
+	}
+
+	for pr := range result {
+		table.Append(genUsageRow(string(configv1alpha1.SecretReferencedResourceKind),
+			pr.Namespace, pr.Name, result[pr]))
+	}
+
+	return nil
+}
+
+func getConfigMaps(passedNamespace, passedName string, clusterProfile *configv1alpha1.ClusterProfile,
+	result map[configv1alpha1.PolicyRef][]string, logger logr.Logger) {
+
+	configMaps := make([]configv1alpha1.PolicyRef, 0)
+	for i := range clusterProfile.Spec.PolicyRefs {
+		pr := &clusterProfile.Spec.PolicyRefs[i]
+		if pr.Kind == string(configv1alpha1.ConfigMapReferencedResourceKind) {
+			if shouldAddPolicyRef(passedNamespace, passedName, pr) {
+				logger.V(logs.LogVerbose).Info(fmt.Sprintf("considering reference configMap %s/%s",
+					pr.Namespace, pr.Name))
+				configMaps = append(configMaps, *pr)
+			}
+		}
+	}
+
+	clusters := getMatchingClusters(clusterProfile)
+
+	for i := range configMaps {
+		cm := &configMaps[i]
+		if _, ok := result[*cm]; !ok {
+			result[*cm] = make([]string, 0)
+		}
+		result[*cm] = append(result[*cm], clusters...)
+	}
+}
+
+func getSecrets(passedNamespace, passedName string, clusterProfile *configv1alpha1.ClusterProfile,
+	result map[configv1alpha1.PolicyRef][]string, logger logr.Logger) {
+
+	secrets := make([]configv1alpha1.PolicyRef, 0)
+	for i := range clusterProfile.Spec.PolicyRefs {
+		pr := &clusterProfile.Spec.PolicyRefs[i]
+		if pr.Kind == string(configv1alpha1.SecretReferencedResourceKind) {
+			if shouldAddPolicyRef(passedNamespace, passedName, pr) {
+				logger.V(logs.LogVerbose).Info(fmt.Sprintf("considering reference secret %s/%s",
+					pr.Namespace, pr.Name))
+				secrets = append(secrets, *pr)
+			}
+		}
+	}
+
+	clusters := getMatchingClusters(clusterProfile)
+
+	for i := range secrets {
+		secret := &secrets[i]
+		if _, ok := result[*secret]; !ok {
+			result[*secret] = make([]string, 0)
+		}
+		result[*secret] = append(result[*secret], clusters...)
+	}
+}
+
+func shouldAddPolicyRef(passedNamespace, passedName string, pr *configv1alpha1.PolicyRef) bool {
+	if passedNamespace != "" &&
+		pr.Namespace != passedNamespace {
+		return false
+	}
+
+	if passedName != "" &&
+		pr.Name != passedName {
+		return false
+	}
+
+	return true
+}
+
+// Usage displays CAPI cluster where policies (ClusterProfiles and referenced ConfigMaps/Secrets) are deployed
+func Usage(ctx context.Context, args []string, logger logr.Logger) error {
+	doc := `Usage:
+  sveltosctl show usage [options] [--kind=<name>] [--namespace=<resourceNamespace>] [--name=<resourceName>] [--verbose]
+
+     --kind=<name>                    Show usage information for resources of this Kind only. If not specified, ClusterProfile and referenced ConfigMap and Secret are considered.
+     --namespace=<resourceNamespace>  Show usage information for resources in this namespace only. If not specified all namespaces are considered.
+     --name=<resourceName>            Show usage information for resources with this name only. If not specified all ClusterProfiles/ConfigMaps/Secrets are considered.
+
+Options:
+  -h --help                  Show this screen.
+     --verbose               Verbose mode. Print each step.  
+
+Description:
+  The show usage command display usage information:
+  - for each ClusterProfile lists all CAPI clusters currently matching;
+  - for each ConfigMap/Secret referenced by at least one ClusterProfile, lists all CAPI clusters where content of such resource is currently deployed.
+`
+	parsedArgs, err := docopt.ParseArgs(doc, nil, "1.0")
+	if err != nil {
+		logger.V(logs.LogVerbose).Error(err, "failed to parse args")
+		return fmt.Errorf(
+			"invalid option: 'sveltosctl %s'. Use flag '--help' to read about a specific subcommand. Error: %w",
+			strings.Join(args, " "),
+			err,
+		)
+	}
+	if len(parsedArgs) == 0 {
+		return nil
+	}
+
+	_ = flag.Lookup("v").Value.Set(fmt.Sprint(logs.LogInfo))
+	verbose := parsedArgs["--verbose"].(bool)
+	if verbose {
+		err = flag.Lookup("v").Value.Set(fmt.Sprint(logs.LogVerbose))
+		if err != nil {
+			return err
+		}
+	}
+
+	namespace := ""
+	if passedNamespace := parsedArgs["--namespace"]; passedNamespace != nil {
+		namespace = passedNamespace.(string)
+	}
+
+	name := ""
+	if passedName := parsedArgs["--name"]; passedName != nil {
+		name = passedName.(string)
+	}
+
+	kind := ""
+	if passedKind := parsedArgs["--kind"]; passedKind != nil {
+		kind = passedKind.(string)
+		if kind != configv1alpha1.ClusterProfileKind &&
+			kind != string(configv1alpha1.ConfigMapReferencedResourceKind) &&
+			kind != string(configv1alpha1.SecretReferencedResourceKind) {
+			return fmt.Errorf("possible values for kind are: %s, %s, %s",
+				configv1alpha1.ClusterProfileKind,
+				string(configv1alpha1.ConfigMapReferencedResourceKind),
+				string(configv1alpha1.SecretReferencedResourceKind),
+			)
+		}
+	}
+
+	return showUsage(ctx, kind, namespace, name, logger)
+}

--- a/internal/commands/show/usage_test.go
+++ b/internal/commands/show/usage_test.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2022. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package show_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2/klogr"
+
+	configv1alpha1 "github.com/projectsveltos/cluster-api-feature-manager/api/v1alpha1"
+	"github.com/projectsveltos/sveltosctl/internal/commands/show"
+	"github.com/projectsveltos/sveltosctl/internal/utils"
+)
+
+var _ = Describe("Usage", func() {
+	It("showUsage displays per resource, associated list of CAPI clusters", func() {
+		configMap := configv1alpha1.PolicyRef{
+			Namespace: randomString(),
+			Name:      randomString(),
+			Kind:      string(configv1alpha1.ConfigMapReferencedResourceKind),
+		}
+
+		secret := configv1alpha1.PolicyRef{
+			Namespace: randomString(),
+			Name:      randomString(),
+			Kind:      string(configv1alpha1.SecretReferencedResourceKind),
+		}
+
+		clusterProfile1 := generateClusterProfile()
+		clusterProfile1.Spec.PolicyRefs = []configv1alpha1.PolicyRef{
+			configMap,
+		}
+		clusterProfile1.Status.MatchingClusterRefs = []corev1.ObjectReference{
+			{Namespace: randomString(), Name: randomString()},
+		}
+
+		clusterProfile2 := generateClusterProfile()
+		clusterProfile2.Spec.PolicyRefs = []configv1alpha1.PolicyRef{
+			secret,
+		}
+		clusterProfile2.Status.MatchingClusterRefs = []corev1.ObjectReference{
+			{Namespace: randomString(), Name: randomString()},
+		}
+
+		old := os.Stdout // keep backup of the real stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+
+		initObjects := []client.Object{clusterProfile1, clusterProfile2}
+		scheme, err := utils.GetScheme()
+		Expect(err).To(BeNil())
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
+
+		utils.InitalizeManagementClusterAcces(scheme, nil, nil, c)
+		err = show.ShowUsage(context.TODO(), "", "", "", klogr.New())
+		Expect(err).To(BeNil())
+
+		w.Close()
+		var buf bytes.Buffer
+		_, err = io.Copy(&buf, r)
+		Expect(err).To(BeNil())
+
+		/*
+			// Example of expected output
+			`+----------------+--------------------+---------------+-----------------------+
+			| RESOURCE KIND  | RESOURCE NAMESPACE | RESOURCE NAME |       CLUSTERS        |
+			+----------------+--------------------+---------------+-----------------------+
+			| ClusterProfile |                    | gauuu53n7r    | hme095dqji/yads0fjhoj |
+			| ClusterProfile |                    | qa8kxyhq9e    | p1d3rlx2sx/5trz9p06tk |
+			| ConfigMap      | gkxc9niba3         | o5fafy6bnn    | hme095dqji/yads0fjhoj |
+			| Secret         | 224c2ibzhz         | qkspgp7vp1    | p1d3rlx2sx/5trz9p06tk |
+			+----------------+--------------------+---------------+-----------------------+`
+		*/
+
+		lines := strings.Split(buf.String(), "\n")
+		verifyClusterProfileUsage(lines, clusterProfile1)
+		verifyClusterProfileUsage(lines, clusterProfile2)
+		verifyUsage(lines, string(configv1alpha1.ConfigMapReferencedResourceKind),
+			configMap.Namespace, configMap.Name, clusterProfile1.Status.MatchingClusterRefs[0])
+		verifyUsage(lines, string(configv1alpha1.SecretReferencedResourceKind),
+			secret.Namespace, secret.Name, clusterProfile2.Status.MatchingClusterRefs[0])
+		os.Stdout = old
+	})
+})
+
+func verifyClusterProfileUsage(lines []string, clusterProfile *configv1alpha1.ClusterProfile) {
+	for i := range clusterProfile.Status.MatchingClusterRefs {
+		verifyUsage(lines, configv1alpha1.ClusterProfileKind, "", clusterProfile.Name,
+			clusterProfile.Status.MatchingClusterRefs[i])
+	}
+}
+
+func verifyUsage(lines []string, kind, namespace, name string, matchingCluster corev1.ObjectReference) {
+	clusterInfo := fmt.Sprintf("%s/%s", matchingCluster.Namespace, matchingCluster.Name)
+	found := false
+	for i := range lines {
+		if strings.Contains(lines[i], kind) &&
+			strings.Contains(lines[i], namespace) &&
+			strings.Contains(lines[i], name) &&
+			strings.Contains(lines[i], clusterInfo) {
+
+			found = true
+		}
+	}
+	Expect(found).To(BeTrue())
+}
+
+func generateClusterProfile() *configv1alpha1.ClusterProfile {
+	return &configv1alpha1.ClusterProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: randomString(),
+		},
+		Spec: configv1alpha1.ClusterProfileSpec{
+			ClusterSelector: configv1alpha1.Selector("zone:west"),
+			SyncMode:        configv1alpha1.SyncModeContinuous,
+		},
+	}
+}


### PR DESCRIPTION
Usage command displays:
1. for each ClusterProfile instance, matching clusters;
1. for each ConfigMap/Secret referenced by at least one ClusterProfile instance, list of clusters where its content is currently deployed.

Such command can be used to see all clusters which might be affected by a configuration change.