### PR TITLE
Rename show features to show addons

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ endif
 REGISTRY ?= projectsveltos
 IMAGE_NAME ?= sveltosctl
 export SVELTOSCTL_IMG ?= $(REGISTRY)/$(IMAGE_NAME) 
-TAG ?= main
+TAG ?= dev
 ARCH ?= amd64
 
 # Directories.

--- a/README.md
+++ b/README.md
@@ -84,14 +84,14 @@ You might also want to change the timezone of sveltosctl pod by using specific t
 
 ## Display deployed resources and helm releases
 
-**show features** can be used to display list of resources/helm releases deployed in CAPI clusters.
+**show addons** can be used to display list of Kubernetes addons (resources/helm) releases deployed in CAPI clusters.
 Displayed information contains:
 1. the CAPI Cluster in the form <namespace>/<name>
 2. resource/helm chart information
 3. list of ClusterProfiles currently (at the time the command is run) having resource/helm release deployed in the CAPI cluster.
 
 ```
-./bin/sveltosctl show features
+./bin/sveltosctl show addons
 +-------------------------------------+---------------+-----------+----------------+---------+-------------------------------+------------------+
 |               CLUSTER               | RESOURCE TYPE | NAMESPACE |      NAME      | VERSION |             TIME              | CLUSTER PROFILE |
 +-------------------------------------+---------------+-----------+----------------+---------+-------------------------------+------------------+
@@ -100,19 +100,19 @@ Displayed information contains:
 +-------------------------------------+---------------+-----------+----------------+---------+-------------------------------+------------------+
 ```
 
-**show features** command has some argurments which allow filtering by:
+**show addons** command has some argurments which allow filtering by:
 1. clusters' namespace
 2. clusters' name
 3. ClusterProfile 
 
 ```
-./bin/sveltosctl show features --help
+./bin/sveltosctl show addons --help
 Usage:
-  sveltosctl show features [options] [--namespace=<name>] [--cluster=<name>] [--clusterprofile=<name>] [--verbose]
+  sveltosctl show addons [options] [--namespace=<name>] [--cluster=<name>] [--clusterprofile=<name>] [--verbose]
 
-     --namespace=<name>      Show features deployed in clusters in this namespace. If not specified all namespaces are considered.
-     --cluster=<name>        Show features deployed in cluster with name. If not specified all cluster names are considered.
-     --clusterprofile=<name> Show features deployed because of this clusterprofile. If not specified all clusterprofile names are considered.
+     --namespace=<name>      Show addons deployed in clusters in this namespace. If not specified all namespaces are considered.
+     --cluster=<name>        Show addons deployed in cluster with name. If not specified all cluster names are considered.
+     --clusterprofile=<name> Show addons deployed because of this clusterprofile. If not specified all clusterprofile names are considered.
 ```
 
 ## Display usage
@@ -205,9 +205,9 @@ Here is an example of outcome
 Usage:
   sveltosctl show dryrun [options] [--namespace=<name>] [--cluster=<name>] [--clusterprofile=<name>] [--verbose]
 
-     --namespace=<name>      Show which features would change in clusters in this namespace. If not specified all namespaces are considered.
-     --cluster=<name>        Show which features would change in cluster with name. If not specified all cluster names are considered.
-     --clusterprofile=<name> Show which features would change because of this clusterprofile. If not specified all clusterprofile names are considered.
+     --namespace=<name>      Show which Kubernetes addons would change in clusters in this namespace. If not specified all namespaces are considered.
+     --cluster=<name>        Show which Kubernetes addons would change in cluster with name. If not specified all cluster names are considered.
+     --clusterprofile=<name> Show which Kubernetes addons would change because of this clusterprofile. If not specified all clusterprofile names are considered.
 ```
 
 ## Techsupport

--- a/cmd/sveltosctl/main.go
+++ b/cmd/sveltosctl/main.go
@@ -42,7 +42,7 @@ func main() {
 	doc := `Usage:
 	sveltosctl [options] <command> [<args>...]
 
-    show           Display information on deployed policies (resources and helm releases) in each cluster
+    show           Display information on deployed Kubernetes addons (resources and helm releases) in each cluster
                    or for ClusterProfiles in DryRun mode, what changes would take effect if the ClusterProfile
                    mode was to be moved out of DryRun mode.
     snapshot       Displays collected snaphost. Visualize diffs between two collected snapshots.

--- a/internal/commands/show.go
+++ b/internal/commands/show.go
@@ -35,7 +35,7 @@ func Show(ctx context.Context, args []string, logger logr.Logger) error {
 	doc := `Usage:
   sveltosctl show [options] <subcommand> [<args>...]
 
-    features      Displays information on policies (resources and helm releases) deployed in clusters.
+    addons        Displays information on Kubernetes addons (resources and helm releases) deployed in clusters.
     usage         Displays information on which CAPI clusters will be affected by a policy (ClusterProfile or referenced ConfigMaps/Secrets) change.
     dryrun        Displays information on ClusterProfiles in DryRun mode. It displays what changes would
                   take effect if a ClusterProfile were to be moved out of DryRun mode.
@@ -71,8 +71,8 @@ See 'sveltosctl show <subcommand> --help' to read about a specific subcommand.
 
 	if opts["<subcommand>"] != nil {
 		switch command {
-		case "features":
-			err = show.Features(ctx, arguments, logger)
+		case "addons":
+			err = show.AddOns(ctx, arguments, logger)
 		case "dryrun":
 			err = show.DryRun(ctx, arguments, logger)
 		case "usage":

--- a/internal/commands/show/addons.go
+++ b/internal/commands/show/addons.go
@@ -39,7 +39,7 @@ var (
 	// lastApplied represents the time resource was updated
 	// clusterProfileNames is the list of all ClusterProfiles causing the resource to be deployed
 	// in the cluster
-	genFeatureRow = func(cluster, resourceType, resourceNamespace, resourceName, resourceVersion,
+	genAddOnsRow = func(cluster, resourceType, resourceNamespace, resourceName, resourceVersion,
 		lastApplied string, clusterProfileNames []string) []string {
 		clusterProfiles := strings.Join(clusterProfileNames, ";")
 		return []string{
@@ -54,13 +54,13 @@ var (
 	}
 )
 
-func displayFeatures(ctx context.Context, passedNamespace, passedCluster, passedClusterProfile string,
+func displayAddOns(ctx context.Context, passedNamespace, passedCluster, passedClusterProfile string,
 	logger logr.Logger) error {
 
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader([]string{"CLUSTER", "RESOURCE TYPE", "NAMESPACE", "NAME", "VERSION", "TIME", "CLUSTER PROFILES"})
 
-	if err := displayFeaturesInNamespaces(ctx, passedNamespace, passedCluster,
+	if err := displayAddOnsInNamespaces(ctx, passedNamespace, passedCluster,
 		passedClusterProfile, table, logger); err != nil {
 		return err
 	}
@@ -70,7 +70,7 @@ func displayFeatures(ctx context.Context, passedNamespace, passedCluster, passed
 	return nil
 }
 
-func displayFeaturesInNamespaces(ctx context.Context, passedNamespace, passedCluster, passedClusterProfile string,
+func displayAddOnsInNamespaces(ctx context.Context, passedNamespace, passedCluster, passedClusterProfile string,
 	table *tablewriter.Table, logger logr.Logger) error {
 
 	instance := utils.GetAccessInstance()
@@ -84,7 +84,7 @@ func displayFeaturesInNamespaces(ctx context.Context, passedNamespace, passedClu
 		ns := &namespaces.Items[i]
 		if doConsiderNamespace(ns, passedNamespace) {
 			logger.V(logs.LogDebug).Info(fmt.Sprintf("Considering namespace: %s", ns.Name))
-			err = displayFeaturesInNamespace(ctx, ns.Name, passedCluster, passedClusterProfile,
+			err = displayAddOnsInNamespace(ctx, ns.Name, passedCluster, passedClusterProfile,
 				table, logger)
 			if err != nil {
 				return err
@@ -95,7 +95,7 @@ func displayFeaturesInNamespaces(ctx context.Context, passedNamespace, passedClu
 	return nil
 }
 
-func displayFeaturesInNamespace(ctx context.Context, namespace, passedCluster, passedClusterProfile string,
+func displayAddOnsInNamespace(ctx context.Context, namespace, passedCluster, passedClusterProfile string,
 	table *tablewriter.Table, logger logr.Logger) error {
 
 	instance := utils.GetAccessInstance()
@@ -111,14 +111,14 @@ func displayFeaturesInNamespace(ctx context.Context, namespace, passedCluster, p
 		cc := &clusterConfigurations.Items[i]
 		if doConsiderClusterConfiguration(cc, passedCluster) {
 			logger.V(logs.LogDebug).Info(fmt.Sprintf("Considering ClusterConfiguration: %s", cc.Name))
-			displayFeaturesForCluster(cc, passedClusterProfile, table, logger)
+			displayAddOnsForCluster(cc, passedClusterProfile, table, logger)
 		}
 	}
 
 	return nil
 }
 
-func displayFeaturesForCluster(clusterConfiguration *configv1alpha1.ClusterConfiguration, passedClusterProfile string,
+func displayAddOnsForCluster(clusterConfiguration *configv1alpha1.ClusterConfiguration, passedClusterProfile string,
 	table *tablewriter.Table, logger logr.Logger) {
 
 	instance := utils.GetAccessInstance()
@@ -132,7 +132,7 @@ func displayFeaturesForCluster(clusterConfiguration *configv1alpha1.ClusterConfi
 	clusterInfo := fmt.Sprintf("%s/%s", clusterConfiguration.Namespace, clusterName)
 	for chart := range helmCharts {
 		if doConsiderClusterProfile(helmCharts[chart], passedClusterProfile) {
-			table.Append(genFeatureRow(clusterInfo, "helm chart", chart.Namespace, chart.ReleaseName, chart.ChartVersion,
+			table.Append(genAddOnsRow(clusterInfo, "helm chart", chart.Namespace, chart.ReleaseName, chart.ChartVersion,
 				chart.LastAppliedTime.String(), helmCharts[chart]))
 		}
 	}
@@ -140,23 +140,23 @@ func displayFeaturesForCluster(clusterConfiguration *configv1alpha1.ClusterConfi
 	resources := instance.GetResources(clusterConfiguration, logger)
 	for resource := range resources {
 		if doConsiderClusterProfile(resources[resource], passedClusterProfile) {
-			table.Append(genFeatureRow(clusterInfo, fmt.Sprintf("%s:%s", resource.Group, resource.Kind),
+			table.Append(genAddOnsRow(clusterInfo, fmt.Sprintf("%s:%s", resource.Group, resource.Kind),
 				resource.Namespace, resource.Name, "N/A",
 				resource.LastAppliedTime.String(), resources[resource]))
 		}
 	}
 }
 
-// Features displays information about features deployed in clusters
-func Features(ctx context.Context, args []string, logger logr.Logger) error {
+// AddOns displays information about Kubernetes AddOns deployed in clusters
+func AddOns(ctx context.Context, args []string, logger logr.Logger) error {
 	doc := `Usage:
-  sveltosctl show features [options] [--namespace=<name>] [--cluster=<name>] [--clusterprofile=<name>] [--verbose]
+  sveltosctl show addons [options] [--namespace=<name>] [--cluster=<name>] [--clusterprofile=<name>] [--verbose]
 
-     --namespace=<name>      Show features deployed in clusters in this namespace.
+     --namespace=<name>      Show Kubernetes addons deployed in clusters in this namespace.
                              If not specified all namespaces are considered.
-     --cluster=<name>        Show features deployed in cluster with name.
+     --cluster=<name>        Show Kubernetes addons deployed in cluster with name.
                              If not specified all cluster names are considered.
-     --clusterprofile=<name> Show features deployed because of this clusterprofile.
+     --clusterprofile=<name> Show Kubernetes addons deployed because of this clusterprofile.
                              If not specified all clusterprofile names are considered.
 
 Options:
@@ -164,7 +164,7 @@ Options:
      --verbose               Verbose mode. Print each step.  
 
 Description:
-  The show features command shows information about features deployed in clusters.
+  The show addons command shows information about Kubernetes addons deployed in clusters.
 `
 	parsedArgs, err := docopt.ParseArgs(doc, nil, "1.0")
 	if err != nil {
@@ -203,5 +203,5 @@ Description:
 		clusterProfile = passedClusterProfile.(string)
 	}
 
-	return displayFeatures(ctx, namespace, cluster, clusterProfile, logger)
+	return displayAddOns(ctx, namespace, cluster, clusterProfile, logger)
 }

--- a/internal/commands/show/addons_test.go
+++ b/internal/commands/show/addons_test.go
@@ -38,7 +38,7 @@ import (
 	"github.com/projectsveltos/sveltosctl/internal/utils"
 )
 
-var _ = Describe("Features", func() {
+var _ = Describe("AddOnss", func() {
 	var clusterConfiguration *configv1alpha1.ClusterConfiguration
 	var ns *corev1.Namespace
 
@@ -59,7 +59,7 @@ var _ = Describe("Features", func() {
 		}
 	})
 
-	It("show features displays deployed helm charts", func() {
+	It("show addonss displays deployed helm charts", func() {
 		clusterProfileName1 := randomString()
 		charts1 := []configv1alpha1.Chart{
 			*generateChart(), *generateChart(),
@@ -83,7 +83,7 @@ var _ = Describe("Features", func() {
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
 
 		utils.InitalizeManagementClusterAcces(scheme, nil, nil, c)
-		err = show.DisplayFeatures(context.TODO(), "", "", "", klogr.New())
+		err = show.DisplayAddOns(context.TODO(), "", "", "", klogr.New())
 		Expect(err).To(BeNil())
 
 		clusterInfo := fmt.Sprintf("%s/%s", clusterConfiguration.Namespace, clusterConfiguration.Name)
@@ -109,7 +109,7 @@ var _ = Describe("Features", func() {
 		os.Stdout = old
 	})
 
-	It("show features display deployed resources", func() {
+	It("show addonss display deployed resources", func() {
 		clusterProfileName1 := randomString()
 		resource1 := []configv1alpha1.Resource{
 			*generateResource(), *generateResource(), *generateResource(),
@@ -133,7 +133,7 @@ var _ = Describe("Features", func() {
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
 
 		utils.InitalizeManagementClusterAcces(scheme, nil, nil, c)
-		err = show.DisplayFeatures(context.TODO(), "", "", "", klogr.New())
+		err = show.DisplayAddOns(context.TODO(), "", "", "", klogr.New())
 		Expect(err).To(BeNil())
 
 		clusterInfo := fmt.Sprintf("%s/%s", clusterConfiguration.Namespace, clusterConfiguration.Name)

--- a/internal/commands/show/dryrun.go
+++ b/internal/commands/show/dryrun.go
@@ -139,16 +139,17 @@ func displayDryRunForCluster(clusterReport *configv1alpha1.ClusterReport, table 
 	}
 }
 
-// DryRun displays information about which features would change in which cluster due to a ClusterProfile currently in DryRun mode,
+// DryRun displays information about which Kubernetes addons would change in which cluster due
+// to a ClusterProfile currently in DryRun mode,
 func DryRun(ctx context.Context, args []string, logger logr.Logger) error {
 	doc := `Usage:
   sveltosctl show dryrun [options] [--namespace=<name>] [--cluster=<name>] [--clusterprofile=<name>] [--verbose]
 
-     --namespace=<name>      Show which features would change in clusters in this namespace.
+     --namespace=<name>      Show which Kubernetes addons would change in clusters in this namespace.
                              If not specified all namespaces are considered.
-     --cluster=<name>        Show which features would change in cluster with name.
+     --cluster=<name>        Show which Kubernetes addons would change in cluster with name.
                              If not specified all cluster names are considered.
-     --clusterprofile=<name> Show which features would change because of this clusterprofile.
+     --clusterprofile=<name> Show which Kubernetes addons would change because of this clusterprofile.
                              If not specified all clusterprofile names are considered.
 
 Options:
@@ -156,7 +157,7 @@ Options:
      --verbose               Verbose mode. Print each step.  
 
 Description:
-  The show dryrun command shows information about which features would change in a cluster due to ClusterProfiles in DryRun mode.
+  The show dryrun command shows information about which Kubernetes addons would change in a cluster due to ClusterProfiles in DryRun mode.
 `
 	parsedArgs, err := docopt.ParseArgs(doc, nil, "1.0")
 	if err != nil {

--- a/internal/commands/show/export_test.go
+++ b/internal/commands/show/export_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package show
 
 var (
-	DisplayFeatures   = displayFeatures
+	DisplayAddOns     = displayAddOns
 	DisplayDryRun     = displayDryRun
 	ShowUsage         = showUsage
 	DisplayAdminRbacs = displayAdminRbacs

--- a/k8s/sveltosctl.yaml
+++ b/k8s/sveltosctl.yaml
@@ -46,7 +46,7 @@ spec:
       serviceAccountName: sveltosctl
       containers:
       - name: sveltosctl
-        image: projectsveltos/sveltosctl-amd64:main
+        image: projectsveltos/sveltosctl-amd64:dev
         imagePullPolicy: IfNotPresent
         command:
           - /sveltosctl

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -46,7 +46,7 @@ spec:
       serviceAccountName: sveltosctl
       containers:
       - name: sveltosctl
-        image: projectsveltos/sveltosctl-amd64:main
+        image: projectsveltos/sveltosctl-amd64:dev
         imagePullPolicy: IfNotPresent
         command:
           - /sveltosctl


### PR DESCRIPTION
Kubernetes addons is the right terms to describe policies deployed by sveltos in each managed cluster.