### PR TITLE
Add show resource command.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ GO_INSTALL := ./scripts/go_install.sh
 REGISTRY ?= projectsveltos
 IMAGE_NAME ?= sveltosctl
 export SVELTOSCTL_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
-TAG ?= main
+TAG ?= dev
 ARCH ?= amd64
 
 # Directories.

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/projectsveltos/addon-controller v0.12.1-0.20230704204117-79a8900a6399
 	github.com/projectsveltos/event-manager v0.12.1-0.20230705123033-06deae70be00
-	github.com/projectsveltos/libsveltos v0.12.1-0.20230704163255-7f5099a7ffd0
+	github.com/projectsveltos/libsveltos v0.12.1-0.20230706135125-94028dd2ba7b
 	github.com/robfig/cron v1.2.0
 	k8s.io/api v0.27.2
 	k8s.io/apiextensions-apiserver v0.27.2

--- a/go.sum
+++ b/go.sum
@@ -563,8 +563,8 @@ github.com/projectsveltos/addon-controller v0.12.1-0.20230704204117-79a8900a6399
 github.com/projectsveltos/addon-controller v0.12.1-0.20230704204117-79a8900a6399/go.mod h1:RtSYmwuHEYSo7ZQe5pkArQsnVgG2mItBXACAQROwVJg=
 github.com/projectsveltos/event-manager v0.12.1-0.20230705123033-06deae70be00 h1:12J6FhnJoItk40LAsltTN2TCiNmgKx1DAkLE2oj6VcA=
 github.com/projectsveltos/event-manager v0.12.1-0.20230705123033-06deae70be00/go.mod h1:YyxE8dOet3BdnIihDd6PZeh9zaoXnArDFATV6zxBm+A=
-github.com/projectsveltos/libsveltos v0.12.1-0.20230704163255-7f5099a7ffd0 h1:URTa73p/hJ/rsXqh+Em2mAcTlQbwKg6Sm2FREqpszwE=
-github.com/projectsveltos/libsveltos v0.12.1-0.20230704163255-7f5099a7ffd0/go.mod h1:2Qq4Iw2e/nYrdI42J6t6Gmkr5S0ozrREzdSAZO17Jkc=
+github.com/projectsveltos/libsveltos v0.12.1-0.20230706135125-94028dd2ba7b h1:MbcZFVTyJVyHgA6968aoVDKSnGCYCeEdSORHxxACkLM=
+github.com/projectsveltos/libsveltos v0.12.1-0.20230706135125-94028dd2ba7b/go.mod h1:2Qq4Iw2e/nYrdI42J6t6Gmkr5S0ozrREzdSAZO17Jkc=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=

--- a/internal/commands/show.go
+++ b/internal/commands/show.go
@@ -36,6 +36,7 @@ func Show(ctx context.Context, args []string, logger logr.Logger) error {
   sveltosctl show [options] <subcommand> [<args>...]
 
     addons        Displays information on Kubernetes addons (resources and helm releases) deployed in clusters.
+    resources     Displays information from resources collected from managed clusters.
     usage         Displays information on which CAPI clusters will be affected by a policy (ClusterProfile or referenced ConfigMaps/Secrets) change.
     dryrun        Displays information on ClusterProfiles in DryRun mode. It displays what changes would
                   take effect if a ClusterProfile were to be moved out of DryRun mode.
@@ -73,6 +74,8 @@ See 'sveltosctl show <subcommand> --help' to read about a specific subcommand.
 		switch command {
 		case "addons":
 			err = show.AddOns(ctx, arguments, logger)
+		case "resources":
+			err = show.Resources(ctx, arguments, logger)
 		case "dryrun":
 			err = show.DryRun(ctx, arguments, logger)
 		case "usage":

--- a/internal/commands/show/addons_test.go
+++ b/internal/commands/show/addons_test.go
@@ -59,7 +59,7 @@ var _ = Describe("AddOnss", func() {
 		}
 	})
 
-	It("show addonss displays deployed helm charts", func() {
+	It("show addons displays deployed helm charts", func() {
 		clusterProfileName1 := randomString()
 		charts1 := []configv1alpha1.Chart{
 			*generateChart(), *generateChart(),

--- a/internal/commands/show/export_test.go
+++ b/internal/commands/show/export_test.go
@@ -21,4 +21,5 @@ var (
 	DisplayDryRun     = displayDryRun
 	ShowUsage         = showUsage
 	DisplayAdminRbacs = displayAdminRbacs
+	DisplayResources  = displayResources
 )

--- a/internal/commands/show/resources.go
+++ b/internal/commands/show/resources.go
@@ -1,0 +1,298 @@
+/*
+Copyright 2022. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package show
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/docopt/docopt-go"
+	"github.com/fatih/color"
+	"github.com/go-logr/logr"
+	"github.com/olekukonko/tablewriter"
+	"gopkg.in/yaml.v2"
+
+	libsveltosv1alpha1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
+	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
+	libsveltosutils "github.com/projectsveltos/libsveltos/lib/utils"
+	"github.com/projectsveltos/sveltosctl/internal/utils"
+)
+
+var (
+	// cluster represents the cluster => namespace/name
+	// gvk represents the resource group/version/kind
+	// resourceNamespace and resourceName is the kubernetes resource namespace/name
+	genResourceRow = func(cluster, resourceGVK, resourceNamespace, resourceName, message string) []string {
+		return []string{
+			cluster,
+			resourceGVK,
+			resourceNamespace,
+			resourceName,
+			message,
+		}
+	}
+)
+
+func displayResources(ctx context.Context,
+	passedClusterNamespace, passedCluster, passedGroup, passedKind, passedNamespace string,
+	full bool, logger logr.Logger) error {
+
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetBorder(true)
+
+	if !full {
+		table.SetHeader([]string{"CLUSTER", "GVK", "NAMESPACE", "NAME", "MESSAGE"})
+		table.SetAutoMergeCellsByColumnIndex([]int{0, 1})
+		table.SetColumnColor(tablewriter.Colors{tablewriter.Bold, tablewriter.FgBlackColor},
+			tablewriter.Colors{tablewriter.Bold, tablewriter.FgBlackColor},
+			tablewriter.Colors{tablewriter.Bold, tablewriter.FgBlackColor},
+			tablewriter.Colors{tablewriter.Bold, tablewriter.FgBlackColor},
+			tablewriter.Colors{tablewriter.Bold, tablewriter.FgBlackColor})
+	}
+
+	if err := displayResourcesInNamespaces(ctx, passedClusterNamespace, passedCluster,
+		passedGroup, passedKind, passedNamespace, full, table, logger); err != nil {
+		return err
+	}
+
+	if !full {
+		table.Render()
+	}
+
+	return nil
+}
+
+func displayResourcesInNamespaces(ctx context.Context,
+	passedClusterNamespace, passedCluster, passedGroup, passedKind, passedNamespace string,
+	full bool, table *tablewriter.Table, logger logr.Logger) error {
+
+	instance := utils.GetAccessInstance()
+
+	healthCheckReports, err := instance.ListHealthCheckReports(ctx, passedClusterNamespace, logger)
+	if err != nil {
+		return err
+	}
+
+	for i := range healthCheckReports.Items {
+		hcr := &healthCheckReports.Items[i]
+		if passedCluster != "" && hcr.Spec.ClusterName != passedCluster {
+			continue
+		}
+		logger.V(logs.LogDebug).Info(fmt.Sprintf("Considering healthCheckReport: %s/%s",
+			hcr.Namespace, hcr.Name))
+		err = displayResourcesInReport(hcr, passedGroup, passedKind, passedNamespace,
+			full, table, logger)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func displayResourcesInReport(healthCheckReport *libsveltosv1alpha1.HealthCheckReport,
+	passedGroup, passedKind, passedNamespace string, full bool,
+	table *tablewriter.Table, logger logr.Logger) error {
+
+	logger = logger.WithValues("healtcheckreport", fmt.Sprintf("%s/%s",
+		healthCheckReport.Namespace, healthCheckReport.Name))
+
+	for i := range healthCheckReport.Spec.ResourceStatuses {
+		resourceStatus := &healthCheckReport.Spec.ResourceStatuses[i]
+		if doConsiderResourceStatus(resourceStatus, passedGroup, passedKind, passedNamespace) {
+			logger.V(logs.LogDebug).Info("Considering resources in healthCheckReport")
+			if full {
+				err := printResource(resourceStatus, healthCheckReport.Spec.ClusterNamespace,
+					healthCheckReport.Spec.ClusterName, logger)
+				if err != nil {
+					return err
+				}
+			} else {
+				displayResource(resourceStatus, healthCheckReport.Spec.ClusterNamespace,
+					healthCheckReport.Spec.ClusterName, table)
+			}
+		}
+	}
+
+	return nil
+}
+
+func displayResource(resourceStatus *libsveltosv1alpha1.ResourceStatus,
+	clusterNamespace, clusterName string, table *tablewriter.Table) {
+
+	clusterInfo := fmt.Sprintf("%s/%s", clusterNamespace, clusterName)
+	gvk := resourceStatus.ObjectRef.GroupVersionKind().String()
+	resourceNamespace := resourceStatus.ObjectRef.Namespace
+	resourceName := resourceStatus.ObjectRef.Name
+	message := resourceStatus.Message
+
+	if resourceStatus.HealthStatus != libsveltosv1alpha1.HealthStatusHealthy {
+		data := []string{clusterInfo, gvk, resourceNamespace, resourceName, message}
+		table.Rich(data, []tablewriter.Colors{{tablewriter.Bold, tablewriter.FgBlackColor},
+			{tablewriter.Bold, tablewriter.FgBlackColor}, {tablewriter.Bold, tablewriter.BgRedColor},
+			{tablewriter.Bold, tablewriter.BgRedColor}, {tablewriter.Bold, tablewriter.FgBlackColor}})
+		return
+	}
+
+	table.Append(genResourceRow(clusterInfo, gvk, resourceNamespace, resourceName, message))
+}
+
+func printResource(resourceStatus *libsveltosv1alpha1.ResourceStatus,
+	clusterNamespace, clusterName string, logger logr.Logger) error {
+
+	clusterInfo := fmt.Sprintf("%s/%s", clusterNamespace, clusterName)
+	gvk := resourceStatus.ObjectRef.GroupVersionKind().String()
+	resourceNamespace := resourceStatus.ObjectRef.Namespace
+	resourceName := resourceStatus.ObjectRef.Name
+
+	if resourceStatus.Resource == nil {
+		logger.V(logs.LogInfo).Info("resources are not collected. Check configuration.")
+		return nil
+	}
+
+	resource, err := libsveltosutils.GetUnstructured(resourceStatus.Resource)
+	if err != nil {
+		logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to get resource %s:%s/%s",
+			gvk, resourceNamespace, resourceName))
+		return err
+	}
+
+	resourceYAML, err := yaml.Marshal(resource)
+	if err != nil {
+		return err
+	}
+
+	if resourceStatus.HealthStatus != libsveltosv1alpha1.HealthStatusHealthy {
+		red := color.New(color.FgRed).SprintfFunc()
+		//nolint: forbidigo // printing results to stdout
+		fmt.Println("Cluster: ", red(clusterInfo))
+	} else {
+		green := color.New(color.FgGreen).SprintfFunc()
+		//nolint: forbidigo // printing results to stdout
+		fmt.Println("Cluster: ", green(clusterInfo))
+	}
+
+	//nolint: forbidigo // printing results to stdout
+	fmt.Println("Object: ", string(resourceYAML))
+
+	return nil
+}
+
+func doConsiderResourceStatus(resourceStatus *libsveltosv1alpha1.ResourceStatus,
+	passedGroup, passedKind, passedNamespace string) bool {
+
+	if passedGroup != "" {
+		if !strings.EqualFold(resourceStatus.ObjectRef.GroupVersionKind().Group, passedGroup) {
+			return false
+		}
+	}
+
+	if passedKind != "" {
+		if !strings.EqualFold(resourceStatus.ObjectRef.GroupVersionKind().Kind, passedKind) {
+			return false
+		}
+	}
+
+	if passedNamespace != "" {
+		if resourceStatus.ObjectRef.Namespace != passedNamespace {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Resources displays information about Kubernetes resources collected from managed clusters
+func Resources(ctx context.Context, args []string, logger logr.Logger) error {
+	doc := `Usage:
+  sveltosctl show resources [options] [--group=<group>] [--kind=<kind>] [--namespace=<namespace>] 
+  [--cluster-namespace=<name>] [--cluster=<name>] [--full] [--verbose]
+
+     --group=<group>              Show Kubernetes resources deployed in clusters matching this group.
+                                  If not specified all groups are considered.
+     --kind=<kind>                Show Kubernetes resources deployed in clusters matching this Kind.
+                                  If not specified all kinds are considered.
+     --namespace=<namespace>      Show Kubernetes resources in this namespace. 
+                                  If not specified all namespaces are considered.
+     --cluster-namespace=<name>   Show Kubernetes resources in clusters in this namespace.
+                                  If not specified all namespaces are considered.
+     --cluster=<name>             Show Kubernetes resources in cluster with name.
+                                  If not specified all cluster names are considered.
+     --full                       If specified, full resources are printed
+
+Options:
+  -h --help                  Show this screen.
+     --verbose               Verbose mode. Print each step.  
+
+Description:
+  The show addons command shows information about Kubernetes addons deployed in clusters.
+`
+	parsedArgs, err := docopt.ParseArgs(doc, nil, "1.0")
+	if err != nil {
+		logger.V(logs.LogInfo).Error(err, "failed to parse args")
+		return fmt.Errorf(
+			"invalid option: 'sveltosctl %s'. Use flag '--help' to read about a specific subcommand. Error: %w",
+			strings.Join(args, " "),
+			err,
+		)
+	}
+	if len(parsedArgs) == 0 {
+		return nil
+	}
+
+	_ = flag.Lookup("v").Value.Set(fmt.Sprint(logs.LogInfo))
+	verbose := parsedArgs["--verbose"].(bool)
+	if verbose {
+		err = flag.Lookup("v").Value.Set(fmt.Sprint(logs.LogDebug))
+		if err != nil {
+			return err
+		}
+	}
+
+	full := parsedArgs["--full"].(bool)
+
+	clusterNamespace := ""
+	if passedClusterNamespace := parsedArgs["--cluster-namespace"]; passedClusterNamespace != nil {
+		clusterNamespace = passedClusterNamespace.(string)
+	}
+
+	cluster := ""
+	if passedCluster := parsedArgs["--cluster"]; passedCluster != nil {
+		cluster = passedCluster.(string)
+	}
+
+	group := ""
+	if passedGroup := parsedArgs["--group"]; passedGroup != nil {
+		group = passedGroup.(string)
+	}
+
+	kind := ""
+	if passedKind := parsedArgs["--kind"]; passedKind != nil {
+		kind = passedKind.(string)
+	}
+
+	namespace := ""
+	if passedNamespace := parsedArgs["--namespace"]; passedNamespace != nil {
+		namespace = passedNamespace.(string)
+	}
+
+	return displayResources(ctx, clusterNamespace, cluster,
+		group, kind, namespace, full, logger)
+}

--- a/internal/commands/show/resources_test.go
+++ b/internal/commands/show/resources_test.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2023. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package show_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2/klogr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	libsveltosv1alpha1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
+	"github.com/projectsveltos/sveltosctl/internal/commands/show"
+	"github.com/projectsveltos/sveltosctl/internal/utils"
+)
+
+var _ = Describe("Resources", func() {
+	It("show resources displays resources from various managed clusters", func() {
+		message := "All replicas 1 are healthy"
+
+		hcr := &libsveltosv1alpha1.HealthCheckReport{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      randomString(),
+				Namespace: randomString(),
+			},
+			Spec: libsveltosv1alpha1.HealthCheckReportSpec{
+				ClusterNamespace: randomString(),
+				ClusterName:      randomString(),
+				ClusterType:      libsveltosv1alpha1.ClusterTypeSveltos,
+				ResourceStatuses: []libsveltosv1alpha1.ResourceStatus{
+					{
+						Resource: nil,
+						ObjectRef: corev1.ObjectReference{
+							Kind:       "Deployment",
+							APIVersion: appsv1.SchemeGroupVersion.String(),
+							Namespace:  randomString(),
+							Name:       randomString(),
+						},
+						Message:      message,
+						HealthStatus: libsveltosv1alpha1.HealthStatusHealthy,
+					},
+					{
+						Resource: nil,
+						ObjectRef: corev1.ObjectReference{
+							Kind:       "Service",
+							APIVersion: corev1.SchemeGroupVersion.String(),
+							Namespace:  randomString(),
+							Name:       randomString(),
+						},
+						Message:      message,
+						HealthStatus: libsveltosv1alpha1.HealthStatusHealthy,
+					},
+				},
+			},
+		}
+
+		old := os.Stdout // keep backup of the real stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+
+		initObjects := []client.Object{hcr}
+
+		scheme, err := utils.GetScheme()
+		Expect(err).To(BeNil())
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
+
+		utils.InitalizeManagementClusterAcces(scheme, nil, nil, c)
+		err = show.DisplayResources(context.TODO(), "", "", "", "", "", false, klogr.New())
+		Expect(err).To(BeNil())
+
+		w.Close()
+		var buf bytes.Buffer
+		_, err = io.Copy(&buf, r)
+		Expect(err).To(BeNil())
+
+		/*
+			// This is an example of how the table needs to look like
+			+-------------------------------------+--------------------------+----------------+-------------------------+----------------------------+
+			|               CLUSTER               |           GVK            |   NAMESPACE    |          NAME           |          MESSAGE           |
+			+-------------------------------------+--------------------------+----------------+-------------------------+----------------------------+
+			| default/sveltos-management-workload | apps/v1, Kind=Deployment | kube-system    | calico-kube-controllers | All replicas 1 are healthy |
+			|                                     |                          | kube-system    | coredns                 | All replicas 2 are healthy |
+			|                                     |                          | projectsveltos | sveltos-agent-manager   | All replicas 1 are healthy |
+			+-------------------------------------+--------------------------+----------------+-------------------------+----------------------------+
+		*/
+
+		lines := strings.Split(buf.String(), "\n")
+		for i := range hcr.Spec.ResourceStatuses {
+			verifyDisplayedResources(lines, &hcr.Spec.ResourceStatuses[i].ObjectRef,
+				hcr.Spec.ResourceStatuses[i].Message)
+		}
+		os.Stdout = old
+	})
+})
+
+func verifyDisplayedResources(lines []string, resource *corev1.ObjectReference, message string) {
+	found := false
+	for i := range lines {
+		if strings.Contains(lines[i], resource.Kind) &&
+			strings.Contains(lines[i], resource.APIVersion) &&
+			strings.Contains(lines[i], resource.Namespace) &&
+			strings.Contains(lines[i], resource.Name) &&
+			strings.Contains(lines[i], message) {
+
+			found = true
+			break
+		}
+	}
+	if found != true {
+		By(fmt.Sprintf("Failed to verify resource %s:%s/%s", resource.Kind, resource.Namespace, resource.Name))
+		By(fmt.Sprintf("Results: %v", lines))
+	}
+	Expect(found).To(BeTrue())
+}

--- a/internal/utils/healthcheckreports.go
+++ b/internal/utils/healthcheckreports.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2023. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	libsveltosv1alpha1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
+	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
+)
+
+// ListHealthCheckReports returns all current HealthCheckReports
+func (a *k8sAccess) ListHealthCheckReports(ctx context.Context, namespace string,
+	logger logr.Logger) (*libsveltosv1alpha1.HealthCheckReportList, error) {
+
+	logger.V(logs.LogDebug).Info("Get all HealthCheckReports")
+
+	listOptions := []client.ListOption{}
+	if namespace != "" {
+		listOptions = []client.ListOption{
+			client.InNamespace(namespace),
+		}
+	}
+
+	healthCheckReports := &libsveltosv1alpha1.HealthCheckReportList{}
+	err := a.client.List(ctx, healthCheckReports, listOptions...)
+	return healthCheckReports, err
+}

--- a/internal/utils/healthcheckreports_test.go
+++ b/internal/utils/healthcheckreports_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2023. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2/klogr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	libsveltosv1alpha1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
+	"github.com/projectsveltos/sveltosctl/internal/utils"
+)
+
+var _ = Describe("HealthCheckReports", func() {
+	It("ListHealthCheckReports returns list of all HealthCheckReports", func() {
+		initObjects := []client.Object{}
+
+		for i := 0; i < 10; i++ {
+			hcr := &libsveltosv1alpha1.HealthCheckReport{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      randomString(),
+					Namespace: randomString(),
+				},
+				Spec: libsveltosv1alpha1.HealthCheckReportSpec{
+					ClusterNamespace: randomString(),
+					ClusterName:      randomString(),
+					ClusterType:      libsveltosv1alpha1.ClusterTypeSveltos,
+					HealthCheckName:  randomString(),
+				},
+			}
+			initObjects = append(initObjects, hcr)
+		}
+
+		scheme := runtime.NewScheme()
+		Expect(utils.AddToScheme(scheme)).To(Succeed())
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
+
+		k8sAccess := utils.GetK8sAccess(scheme, c)
+		healthCheckReports, err := k8sAccess.ListHealthCheckReports(context.TODO(), "", klogr.New())
+		Expect(err).To(BeNil())
+		Expect(len(healthCheckReports.Items)).To(Equal(len(initObjects)))
+	})
+
+	It("ListHealthCheckReports returns list of all HealthCheckReports in a given namespace", func() {
+		initObjects := []client.Object{}
+
+		for i := 0; i < 10; i++ {
+			hcr := &libsveltosv1alpha1.HealthCheckReport{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      randomString(),
+					Namespace: randomString(),
+				},
+				Spec: libsveltosv1alpha1.HealthCheckReportSpec{
+					ClusterNamespace: randomString(),
+					ClusterName:      randomString(),
+					ClusterType:      libsveltosv1alpha1.ClusterTypeSveltos,
+					HealthCheckName:  randomString(),
+				},
+			}
+			initObjects = append(initObjects, hcr)
+		}
+
+		hcr := &libsveltosv1alpha1.HealthCheckReport{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      randomString(),
+				Namespace: randomString(),
+			},
+			Spec: libsveltosv1alpha1.HealthCheckReportSpec{
+				ClusterNamespace: randomString(),
+				ClusterName:      randomString(),
+				ClusterType:      libsveltosv1alpha1.ClusterTypeSveltos,
+				HealthCheckName:  randomString(),
+			},
+		}
+		initObjects = append(initObjects, hcr)
+
+		scheme := runtime.NewScheme()
+		Expect(utils.AddToScheme(scheme)).To(Succeed())
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
+
+		k8sAccess := utils.GetK8sAccess(scheme, c)
+		healthCheckReports, err := k8sAccess.ListHealthCheckReports(context.TODO(), hcr.Namespace, klogr.New())
+		Expect(err).To(BeNil())
+		Expect(len(healthCheckReports.Items)).To(Equal(1))
+	})
+})

--- a/k8s/sveltosctl.yaml
+++ b/k8s/sveltosctl.yaml
@@ -116,6 +116,7 @@ rules:
       - classifiers
       - eventsources
       - healthchecks
+      - healthcheckreports
       - eventbasedaddons
       - addoncompliances
     verbs:

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -46,7 +46,7 @@ spec:
       serviceAccountName: sveltosctl
       containers:
       - name: sveltosctl
-        image: projectsveltos/sveltosctl-amd64:main
+        image: projectsveltos/sveltosctl-amd64:dev
         imagePullPolicy: IfNotPresent
         command:
           - /sveltosctl


### PR DESCRIPTION
This command looks at all the HealthCheckReport instances and display information about those.

For instance:

```
+-------------------------------------+--------------------------+----------------+-------------------------+----------------------------+
|               CLUSTER               |           GVK            |   NAMESPACE    |          NAME           |          MESSAGE           |
+-------------------------------------+--------------------------+----------------+-------------------------+----------------------------+
| default/sveltos-management-workload | apps/v1, Kind=Deployment | kube-system    | calico-kube-controllers | All replicas 1 are healthy |
|                                     |                          | kube-system    | coredns                 | All replicas 2 are healthy |
|                                     |                          | projectsveltos | sveltos-agent-manager   | All replicas 1 are healthy |
+-------------------------------------+--------------------------+----------------+-------------------------+----------------------------+
```

Command as also option --full.
When set full resource will be displayed

```
Cluster:  default/sveltos-management-workload
Object:  object:
  apiVersion: apps/v1
  kind: Deployment
  metadata:
    annotations:
      deployment.kubernetes.io/revision: "1"
    creationTimestamp: "2023-07-07T11:23:41Z"
    generation: 1
    labels:
      k8s-app: kube-dns
    managedFields:
    - apiVersion: apps/v1
      fieldsType: FieldsV1
      fieldsV1:
        f:metadata:
          f:labels:
            .: {}
            f:k8s-app: {}
        f:spec:
...
```