### PR TITLE
show addons: fix cluster filter

### DIFF
--- a/internal/commands/show/utils.go
+++ b/internal/commands/show/utils.go
@@ -37,7 +37,12 @@ func doConsiderClusterConfiguration(clusterConfiguration *configv1alpha1.Cluster
 		return true
 	}
 
-	return clusterConfiguration.Name == passedCluster
+	if clusterConfiguration.Labels == nil {
+		return false
+	}
+
+	clusterName := clusterConfiguration.Labels[configv1alpha1.ClusterNameLabel]
+	return clusterName == passedCluster
 }
 
 func doConsiderClusterReport(clusterReport *configv1alpha1.ClusterReport,


### PR DESCRIPTION
When displaying deployed add-ons, command allows filtering by namespace and cluster name.
Because of an issue, filtering by cluster name was returning no result.

This PR fixes it.

```
sveltosctl show addons
+-----------------------------+---------------+-----------+----------------+---------+-------------------------------+------------------------+
|           CLUSTER           | RESOURCE TYPE | NAMESPACE |      NAME      | VERSION |             TIME              |        PROFILES        |
+-----------------------------+---------------+-----------+----------------+---------+-------------------------------+------------------------+
| default/clusterapi-workload | helm chart    | kyverno   | kyverno-latest | 3.0.1   | 2024-02-14 16:12:47 +0100 CET | ClusterProfile/kyverno |
| default/clusterapi-workload | helm chart    | nginx     | nginx-latest   | 0.14.0  | 2024-02-14 16:14:50 +0100 CET | ClusterProfile/kyverno |
+-----------------------------+---------------+-----------+----------------+---------+-------------------------------+------------------------+
```

Filter by namespace

```
sveltosctl show addons --namespace=default
+-----------------------------+---------------+-----------+----------------+---------+-------------------------------+------------------------+
|           CLUSTER           | RESOURCE TYPE | NAMESPACE |      NAME      | VERSION |             TIME              |        PROFILES        |
+-----------------------------+---------------+-----------+----------------+---------+-------------------------------+------------------------+
| default/clusterapi-workload | helm chart    | kyverno   | kyverno-latest | 3.0.1   | 2024-02-14 16:12:47 +0100 CET | ClusterProfile/kyverno |
| default/clusterapi-workload | helm chart    | nginx     | nginx-latest   | 0.14.0  | 2024-02-14 16:14:50 +0100 CET | ClusterProfile/kyverno |
+-----------------------------+---------------+-----------+----------------+---------+-------------------------------+------------------------+
```

Filter by namespace and cluster name

```
sveltosctl show addons --namespace=default  --cluster=clusterapi-workload
+-----------------------------+---------------+-----------+----------------+---------+-------------------------------+------------------------+
|           CLUSTER           | RESOURCE TYPE | NAMESPACE |      NAME      | VERSION |             TIME              |        PROFILES        |
+-----------------------------+---------------+-----------+----------------+---------+-------------------------------+------------------------+
| default/clusterapi-workload | helm chart    | kyverno   | kyverno-latest | 3.0.1   | 2024-02-14 16:12:47 +0100 CET | ClusterProfile/kyverno |
| default/clusterapi-workload | helm chart    | nginx     | nginx-latest   | 0.14.0  | 2024-02-14 16:14:50 +0100 CET | ClusterProfile/kyverno |
+-----------------------------+---------------+-----------+----------------+---------+-------------------------------+------------------------+
```

Fixes #210 
