### PR TITLE
Enhance generate kubeconfig description

### DIFF
--- a/internal/commands/generate/generate_kubeconfig.go
+++ b/internal/commands/generate/generate_kubeconfig.go
@@ -269,24 +269,29 @@ func GenerateKubeconfig(ctx context.Context, args []string, logger logr.Logger) 
 	doc := `Usage:
   sveltosctl generate kubeconfig [options] [--namespace=<name>] [--serviceaccount=<name>] [--create] [--verbose]
 
-     --namespace=<name>      The namespace of the ServiceAccount. If not specified, projectsveltos namespace will be used.
-     --serviceaccount=<name> The name of the ServiceAccount. If not specified, projectsveltos will be used.
-     --create                If a ServiceAccount with enough permissions is already present, do not set this flag.
-                             Sveltos will generate a Kubeconfig associated to that ServiceAccount.
-                             If a ServiceAccount with cluster admin permissions needs to be created, use this option.
-                             When this option is set, this command will create necessary resources:
-                             1. namespace if not existing already
-                             2. serviceAccount if not existing already
-                             3. ClusterRole with cluster admin permission
-                             4. ClusterRoleBinding granting the serviceAccount cluster admin permissions
-                             5. TokenRequest for the ServiceAccount							 
+     --namespace=<name>      (Optional) Specifies the namespace of the ServiceAccount to use. If not provided, the "projectsveltos" namespace will be used.
+     --serviceaccount=<name> (Optional) Specifies the name of the ServiceAccount to use. If not provided, "projectsveltos" will be used.
+     --create                (Optional) If set, Sveltos will create the necessary resources if they don't already exist:
+                             - The specified namespace (if not already present)
+                             - The specified ServiceAccount (if not already present)
+                             - A ClusterRole with cluster-admin permissions
+                             - A ClusterRoleBinding granting the ServiceAccount cluster-admin permissions
+
+Process:
+
+Sveltos will either use an existing ServiceAccount with sufficient permissions (if --create is not set) or create a new one with 
+cluster-admin permissions (if --create is set).
+Sveltos will generate a TokenRequest for the chosen ServiceAccount. Based on the TokenRequest, Sveltos will generate a kubeconfig 
+file and output it.
+The Kubeconfig can then be used with "sveltosctl register cluster" command.
 
 Options:
   -h --help                  Show this screen.
      --verbose               Verbose mode. Print each step.  
 
 Description:
-  The generate kubeconfig command will generate a Kubeconfig that can later on be used to register the cluster.
+This command helps you set up credentials (kubeconfig) to access a Kubernetes cluster using Sveltos. It allows you to specify a ServiceAccount 
+or create a new one with the necessary permissions.
 `
 	parsedArgs, err := docopt.ParseArgs(doc, nil, "1.0")
 	if err != nil {

--- a/internal/commands/onboard/cluster_test.go
+++ b/internal/commands/onboard/cluster_test.go
@@ -19,6 +19,7 @@ package onboard_test
 import (
 	"context"
 	"os"
+	"reflect"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -58,8 +59,13 @@ var _ = Describe("OnboardCluster", func() {
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
 		utils.InitalizeManagementClusterAcces(scheme, nil, nil, c)
 
-		Expect(onboard.OnboardSveltosCluster(context.TODO(), clusterNamespace, clusterName,
-			kubeconfigFile.Name(), textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(Succeed())
+		labels := map[string]string{
+			randomString(): randomString(),
+			randomString(): randomString(),
+		}
+
+		Expect(onboard.OnboardSveltosCluster(context.TODO(), clusterNamespace, clusterName, kubeconfigFile.Name(),
+			labels, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(Succeed())
 
 		instance := utils.GetAccessInstance()
 
@@ -67,6 +73,7 @@ var _ = Describe("OnboardCluster", func() {
 		err = instance.GetResource(context.TODO(),
 			types.NamespacedName{Namespace: clusterNamespace, Name: clusterName}, sveltosCluster)
 		Expect(err).To(BeNil())
+		Expect(reflect.DeepEqual(sveltosCluster.Labels, labels)).To(BeTrue())
 
 		secret := &corev1.Secret{}
 		secretName := clusterName + onboard.SveltosKubeconfigSecretNamePostfix
@@ -74,6 +81,15 @@ var _ = Describe("OnboardCluster", func() {
 		Expect(err).To(BeNil())
 
 		Expect(secret.Data).ToNot(BeNil())
-		Expect(secret.Data["value"]).To(Equal([]byte(data)))
+		Expect(secret.Data[onboard.Kubeconfig]).To(Equal([]byte(data)))
+
+		// verify operation updates existing resources
+		labels = map[string]string{
+			randomString(): randomString(),
+			randomString(): randomString(),
+		}
+
+		Expect(onboard.OnboardSveltosCluster(context.TODO(), clusterNamespace, clusterName, kubeconfigFile.Name(),
+			labels, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(Succeed())
 	})
 })

--- a/internal/commands/onboard/export_test.go
+++ b/internal/commands/onboard/export_test.go
@@ -22,8 +22,5 @@ var (
 
 const (
 	SveltosKubeconfigSecretNamePostfix = sveltosKubeconfigSecretNamePostfix
-)
-
-var (
-	CreateSveltosCluster = createSveltosCluster
+	Kubeconfig                         = kubeconfig
 )


### PR DESCRIPTION
This PR also modifies the `sveltosctl register cluster` command by allowing labels to be specified.

For instance

```
sveltosctl register cluster \
  --namespace=monitoring \
  --cluster=prod-cluster \
  --kubeconfig=~/.kube/prod-cluster.config \
  --labels=environment=production,tier=backend
```

This command registers a cluster named "prod-cluster" in the "monitoring" namespace with labels "environment=production" and "tier=backend".

Register a cluster means creates a SveltosCluster instance in the "monitoring" namespace named "prod-cluster" with labels "environment=production" and "tier=backend".