### PR TITLE
Fix issue with register cluster

### DIFF
--- a/internal/commands/generate/generate_kubeconfig_test.go
+++ b/internal/commands/generate/generate_kubeconfig_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Register Mgmt Cluster", func() {
 		utils.InitalizeManagementClusterAcces(scheme, nil, nil, c)
 
 		ns := randomString()
-		Expect(generate.CreateNamespace(context.TODO(), ns,
+		Expect(generate.CreateNamespace(context.TODO(), c, ns,
 			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(Succeed())
 
 		currentNs := &corev1.Namespace{}
@@ -53,14 +53,14 @@ var _ = Describe("Register Mgmt Cluster", func() {
 		c := fake.NewClientBuilder().WithScheme(scheme).Build()
 		utils.InitalizeManagementClusterAcces(scheme, nil, nil, c)
 
-		Expect(generate.CreateClusterRole(context.TODO(), generate.Projectsveltos,
+		Expect(generate.CreateClusterRole(context.TODO(), c, generate.Projectsveltos,
 			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(Succeed())
 
 		currentClusterRole := &rbacv1.ClusterRole{}
 		Expect(c.Get(context.TODO(), types.NamespacedName{Name: generate.Projectsveltos},
 			currentClusterRole)).To(Succeed())
 
-		Expect(generate.CreateClusterRole(context.TODO(), generate.Projectsveltos,
+		Expect(generate.CreateClusterRole(context.TODO(), c, generate.Projectsveltos,
 			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(Succeed())
 	})
 
@@ -72,7 +72,7 @@ var _ = Describe("Register Mgmt Cluster", func() {
 
 		saNamespace := randomString()
 		saName := randomString()
-		Expect(generate.CreateClusterRoleBinding(context.TODO(), generate.Projectsveltos,
+		Expect(generate.CreateClusterRoleBinding(context.TODO(), c, generate.Projectsveltos,
 			generate.Projectsveltos, saNamespace, saName,
 			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(Succeed())
 
@@ -88,7 +88,7 @@ var _ = Describe("Register Mgmt Cluster", func() {
 		Expect(currentClusterRoleBinding.Subjects[0].Namespace).To(Equal(saNamespace))
 		Expect(currentClusterRoleBinding.Subjects[0].Kind).To(Equal("ServiceAccount"))
 
-		Expect(generate.CreateClusterRoleBinding(context.TODO(), generate.Projectsveltos,
+		Expect(generate.CreateClusterRoleBinding(context.TODO(), c, generate.Projectsveltos,
 			generate.Projectsveltos, saNamespace, saName,
 			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(Succeed())
 	})

--- a/internal/commands/onboard/cluster.go
+++ b/internal/commands/onboard/cluster.go
@@ -30,7 +30,9 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	libsveltosv1alpha1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
 	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
@@ -265,9 +267,16 @@ func createKubeconfig(ctx context.Context, fleetClusterContext string, logger lo
 	}
 	logger.V(logs.LogDebug).Info(fmt.Sprintf("switched to context %s", fleetClusterContext))
 
+	var remoteRestConfig *rest.Config
+	remoteRestConfig, err = ctrl.GetConfig()
+	if err != nil {
+		return "", err
+	}
+
 	logger.V(logs.LogDebug).Info("Generate Kubeconfig")
 	var data string
-	data, err = generate.GenerateKubeconfigForServiceAccount(ctx, generate.Projectsveltos, generate.Projectsveltos, 0, true, false, logger)
+	data, err = generate.GenerateKubeconfigForServiceAccount(ctx, remoteRestConfig, generate.Projectsveltos, generate.Projectsveltos,
+		0, true, false, logger)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
When fleet-cluster-context is used, after switching context, get the new kubeconfig and use it to get host and CA data.