### PR TITLE
Always reset context

### DIFF
--- a/internal/commands/onboard/cluster.go
+++ b/internal/commands/onboard/cluster.go
@@ -221,7 +221,15 @@ Description:
 func getKubeconfigData(ctx context.Context, kubeconfigFile, fleetClusterContext string, logger logr.Logger) ([]byte, error) {
 	var data []byte
 	if fleetClusterContext != "" {
+		currentContext, err := getCurrentContext()
+		if err != nil {
+			return nil, err
+		}
 		kubeconfigData, err := createKubeconfig(ctx, fleetClusterContext, logger)
+		if err != nil {
+			return nil, err
+		}
+		err = switchCurrentContext(currentContext)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
When register cluster is used with the fleet-cluster-context always reset context to default. In case there is any failure this will avoid changing the context without resetting it back