### PR TITLE
(feat) dryRun message for helm charts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.36.0
 	github.com/pkg/errors v0.9.1
-	github.com/projectsveltos/addon-controller v0.43.1-0.20241202100654-55c0786240ee
+	github.com/projectsveltos/addon-controller v0.43.1-0.20241205122806-925d0b3abd6d
 	github.com/projectsveltos/event-manager v0.43.1-0.20241202114051-1c0a0d0cadee
 	github.com/projectsveltos/libsveltos v0.43.1-0.20241201131544-c4c2550af4af
 	github.com/robfig/cron/v3 v3.0.1
@@ -24,7 +24,7 @@ require (
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/kubectl v0.31.3
 	sigs.k8s.io/cluster-api v1.8.5
-	sigs.k8s.io/controller-runtime v0.19.2
+	sigs.k8s.io/controller-runtime v0.19.3
 	sigs.k8s.io/yaml v1.4.0
 )
 
@@ -35,7 +35,6 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.12.1 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
-	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,6 @@ github.com/evanphx/json-patch/v5 v5.9.0 h1:kcBlZQbplgElYIlo/n1hJbls2z/1awpXxpRi0
 github.com/evanphx/json-patch/v5 v5.9.0/go.mod h1:VNkHZ/282BpEyt/tObQO8s5CMPmYYq14uClGH4abBuQ=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
-github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
-github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
 github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
 github.com/gdexlab/go-render v1.0.1 h1:rxqB3vo5s4n1kF0ySmoNeSPRYkEsyHgln4jFIQY7v0U=
@@ -102,8 +100,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/projectsveltos/addon-controller v0.43.1-0.20241202100654-55c0786240ee h1:rkbzO6c5ttqDk1KAtbr3HPSquT5AO4eaa388NNgiCRc=
-github.com/projectsveltos/addon-controller v0.43.1-0.20241202100654-55c0786240ee/go.mod h1:Mg0CsrS5NLlvKL5kIjqLznmvVE63Guj2aK+23k0kf0Y=
+github.com/projectsveltos/addon-controller v0.43.1-0.20241205122806-925d0b3abd6d h1:fVysR/pJ6ynBDcLBY4Hj9swrFiFr14+aJynGjCNu3w4=
+github.com/projectsveltos/addon-controller v0.43.1-0.20241205122806-925d0b3abd6d/go.mod h1:6iBdXE7wlecOH/c4BeLFNaoIHzk5lEvdrzD1s/w2ReE=
 github.com/projectsveltos/event-manager v0.43.1-0.20241202114051-1c0a0d0cadee h1:JtYRf4FocJZCwswqMMdB2J7+9hQITW3kYnt9ftdLOMA=
 github.com/projectsveltos/event-manager v0.43.1-0.20241202114051-1c0a0d0cadee/go.mod h1:XyJhynQqut5bUGdjGHCDpIOyf/rJv4KETlvJ7cr/V+s=
 github.com/projectsveltos/libsveltos v0.43.1-0.20241201131544-c4c2550af4af h1:rkf6H9XqWmO10dTmZIsns7Zgcw4+vvnLa1bUrURPoJA=
@@ -226,8 +224,8 @@ k8s.io/utils v0.0.0-20241104163129-6fe5fd82f078 h1:jGnCPejIetjiy2gqaJ5V0NLwTpF4w
 k8s.io/utils v0.0.0-20241104163129-6fe5fd82f078/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/cluster-api v1.8.5 h1:lNA2fPN4fkXEs+oOQlnwxT/4VwRFBpv5kkSoJG8nqBA=
 sigs.k8s.io/cluster-api v1.8.5/go.mod h1:pXv5LqLxuIbhGIXykyNKiJh+KrLweSBajVHHitPLyoY=
-sigs.k8s.io/controller-runtime v0.19.2 h1:3sPrF58XQEPzbE8T81TN6selQIMGbtYwuaJ6eDssDF8=
-sigs.k8s.io/controller-runtime v0.19.2/go.mod h1:iRmWllt8IlaLjvTTDLhRBXIEtkCK6hwVBJJsYS9Ajf4=
+sigs.k8s.io/controller-runtime v0.19.3 h1:XO2GvC9OPftRst6xWCpTgBZO04S2cbp0Qqkj8bX1sPw=
+sigs.k8s.io/controller-runtime v0.19.3/go.mod h1:j4j87DqtsThvwTv5/Tc5NFRyyF/RF0ip4+62tbTSIUM=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1 h1:150L+0vs/8DA78h1u02ooW1/fFq/Lwr+sGiqlzvrtq4=

--- a/internal/collector/client_test.go
+++ b/internal/collector/client_test.go
@@ -27,7 +27,7 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/klog/v2/textlogger"
 
-	configv1alpha1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	"github.com/projectsveltos/sveltosctl/internal/collector"
 )
 
@@ -242,7 +242,7 @@ var _ = Describe("Client", func() {
 		u, err := instance.GetUnstructured([]byte(clusterConfigurationInstance))
 		Expect(err).To(BeNil())
 		Expect(u).ToNot(BeNil())
-		Expect(u.GetKind()).To(Equal(configv1alpha1.ClusterConfigurationKind))
+		Expect(u.GetKind()).To(Equal(configv1beta1.ClusterConfigurationKind))
 	})
 
 	It("getResourcesForKind returns all resources of a given namespaced kind", func() {
@@ -258,7 +258,7 @@ var _ = Describe("Client", func() {
 			namespaceFolder := filepath.Join(snapshotFolder, files[i].Name())
 			By(fmt.Sprintf("finding resources in folder %s", namespaceFolder))
 			instance := collector.GetClient()
-			list, err := collector.GetResourcesForKind(instance, namespaceFolder, configv1alpha1.ClusterConfigurationKind,
+			list, err := collector.GetResourcesForKind(instance, namespaceFolder, configv1beta1.ClusterConfigurationKind,
 				textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
 			Expect(err).To(BeNil())
 			Expect(list).ToNot(BeNil())
@@ -277,7 +277,7 @@ var _ = Describe("Client", func() {
 
 		By(fmt.Sprintf("finding resources in folder %s", snapshotFolder))
 		instance := collector.GetClient()
-		list, err := collector.GetResourcesForKind(instance, snapshotFolder, configv1alpha1.ClusterProfileKind,
+		list, err := collector.GetResourcesForKind(instance, snapshotFolder, configv1beta1.ClusterProfileKind,
 			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
 		Expect(err).To(BeNil())
 		Expect(list).ToNot(BeNil())
@@ -289,7 +289,7 @@ var _ = Describe("Client", func() {
 		defer os.RemoveAll(snapshotFolder)
 
 		d := collector.GetClient()
-		resourceMap, err := d.GetNamespacedResources(snapshotFolder, configv1alpha1.ClusterConfigurationKind,
+		resourceMap, err := d.GetNamespacedResources(snapshotFolder, configv1beta1.ClusterConfigurationKind,
 			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
 		Expect(err).To(BeNil())
 		Expect(resourceMap).ToNot(BeNil())
@@ -300,7 +300,7 @@ var _ = Describe("Client", func() {
 			for j := range resources {
 				u := resources[j]
 				Expect(u.GetNamespace()).To(Equal(k))
-				Expect(u.GetKind()).To(Equal(configv1alpha1.ClusterConfigurationKind))
+				Expect(u.GetKind()).To(Equal(configv1beta1.ClusterConfigurationKind))
 			}
 		}
 	})

--- a/internal/collector/collector_suite_test.go
+++ b/internal/collector/collector_suite_test.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/cluster-api/util"
 
-	configv1alpha1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 )
 
@@ -39,30 +39,30 @@ func randomString() string {
 	return util.RandomString(length)
 }
 
-func generateClusterProfile() *configv1alpha1.ClusterProfile {
-	return &configv1alpha1.ClusterProfile{
+func generateClusterProfile() *configv1beta1.ClusterProfile {
+	return &configv1beta1.ClusterProfile{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: randomString(),
 		},
-		Spec: configv1alpha1.Spec{
+		Spec: configv1beta1.Spec{
 			ClusterSelector: libsveltosv1beta1.Selector{
 				LabelSelector: metav1.LabelSelector{
 					MatchLabels: map[string]string{"zone": "west"},
 				},
 			},
-			SyncMode: configv1alpha1.SyncModeContinuous,
+			SyncMode: configv1beta1.SyncModeContinuous,
 		},
 	}
 }
 
-func generateClusterConfiguration() *configv1alpha1.ClusterConfiguration {
-	return &configv1alpha1.ClusterConfiguration{
+func generateClusterConfiguration() *configv1beta1.ClusterConfiguration {
+	return &configv1beta1.ClusterConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      randomString(),
 			Namespace: randomString(),
 		},
-		Status: configv1alpha1.ClusterConfigurationStatus{
-			ClusterProfileResources: []configv1alpha1.ClusterProfileResource{
+		Status: configv1beta1.ClusterConfigurationStatus{
+			ClusterProfileResources: []configv1beta1.ClusterProfileResource{
 				{
 					ClusterProfileName: randomString(),
 				},

--- a/internal/commands/show/addons.go
+++ b/internal/commands/show/addons.go
@@ -27,7 +27,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/olekukonko/tablewriter"
 
-	configv1alpha1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
 	"github.com/projectsveltos/sveltosctl/internal/utils"
 )
@@ -118,7 +118,7 @@ func displayAddOnsInNamespace(ctx context.Context, namespace, passedCluster, pas
 	return nil
 }
 
-func displayAddOnsForCluster(clusterConfiguration *configv1alpha1.ClusterConfiguration, passedProfile string,
+func displayAddOnsForCluster(clusterConfiguration *configv1beta1.ClusterConfiguration, passedProfile string,
 	table *tablewriter.Table, logger logr.Logger) {
 
 	instance := utils.GetAccessInstance()

--- a/internal/commands/show/addons_test.go
+++ b/internal/commands/show/addons_test.go
@@ -33,19 +33,19 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	configv1alpha1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	"github.com/projectsveltos/sveltosctl/internal/commands/show"
 	"github.com/projectsveltos/sveltosctl/internal/utils"
 )
 
 var _ = Describe("AddOnss", func() {
-	var clusterConfiguration *configv1alpha1.ClusterConfiguration
+	var clusterConfiguration *configv1beta1.ClusterConfiguration
 	var ns *corev1.Namespace
 
 	BeforeEach(func() {
 		namespace := namePrefix + randomString()
 
-		clusterConfiguration = &configv1alpha1.ClusterConfiguration{
+		clusterConfiguration = &configv1beta1.ClusterConfiguration{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,
 				Name:      randomString(),
@@ -61,13 +61,13 @@ var _ = Describe("AddOnss", func() {
 
 	It("show addons displays deployed helm charts", func() {
 		clusterProfileName1 := randomString()
-		charts1 := []configv1alpha1.Chart{
+		charts1 := []configv1beta1.Chart{
 			*generateChart(), *generateChart(),
 		}
 		clusterConfiguration = addDeployedHelmCharts(clusterConfiguration, clusterProfileName1, charts1)
 
 		clusterProfileName2 := randomString()
-		charts2 := []configv1alpha1.Chart{
+		charts2 := []configv1beta1.Chart{
 			*generateChart(), *generateChart(), *generateChart(),
 		}
 		clusterConfiguration = addDeployedHelmCharts(clusterConfiguration, clusterProfileName2, charts2)
@@ -112,13 +112,13 @@ var _ = Describe("AddOnss", func() {
 
 	It("show addonss display deployed resources", func() {
 		clusterProfileName1 := randomString()
-		resource1 := []configv1alpha1.Resource{
+		resource1 := []configv1beta1.Resource{
 			*generateResource(), *generateResource(), *generateResource(),
 		}
 		clusterConfiguration = addDeployedResources(clusterConfiguration, clusterProfileName1, resource1)
 
 		clusterProfileName2 := randomString()
-		resource2 := []configv1alpha1.Resource{
+		resource2 := []configv1beta1.Resource{
 			*generateResource(), *generateResource(), *generateResource(),
 		}
 		clusterConfiguration = addDeployedResources(clusterConfiguration, clusterProfileName2, resource2)
@@ -163,7 +163,7 @@ var _ = Describe("AddOnss", func() {
 })
 
 func verifyCharts(lines []string, clusterInfo, clusterProfileName string,
-	charts []configv1alpha1.Chart) {
+	charts []configv1beta1.Chart) {
 
 	for i := range charts {
 		verifyChart(lines, clusterInfo, clusterProfileName, &charts[i])
@@ -171,7 +171,7 @@ func verifyCharts(lines []string, clusterInfo, clusterProfileName string,
 }
 
 func verifyChart(lines []string, clusterInfo, clusterProfileName string,
-	chart *configv1alpha1.Chart) {
+	chart *configv1beta1.Chart) {
 
 	found := false
 	for i := range lines {
@@ -192,7 +192,7 @@ func verifyChart(lines []string, clusterInfo, clusterProfileName string,
 }
 
 func verifyResources(lines []string, clusterInfo, clusterProfileName string,
-	resources []configv1alpha1.Resource) {
+	resources []configv1beta1.Resource) {
 
 	for i := range resources {
 		verifyResource(lines, clusterInfo, clusterProfileName, &resources[i])
@@ -200,7 +200,7 @@ func verifyResources(lines []string, clusterInfo, clusterProfileName string,
 }
 
 func verifyResource(lines []string, clusterInfo, clusterProfileName string,
-	resource *configv1alpha1.Resource) {
+	resource *configv1beta1.Resource) {
 
 	found := false
 	for i := range lines {

--- a/internal/commands/show/dryrun_test.go
+++ b/internal/commands/show/dryrun_test.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	configv1alpha1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	"github.com/projectsveltos/sveltosctl/internal/commands/show"
 	"github.com/projectsveltos/sveltosctl/internal/utils"
 )
@@ -55,49 +55,63 @@ var _ = Describe("DryRun", func() {
 		clusterNamespace := ns.Name
 		clusterName := randomString()
 
-		releaseReports1 := []configv1alpha1.ReleaseReport{
-			*generateReleaseReport(string(configv1alpha1.HelmChartActionInstall)),
-			*generateReleaseReport(string(configv1alpha1.NoHelmAction)),
+		releaseReports1 := []configv1beta1.ReleaseReport{
+			*generateReleaseReport(string(configv1beta1.HelmChartActionInstall)),
+			*generateReleaseReport(string(configv1beta1.NoHelmAction)),
 		}
 
 		clusterProfileName1 := randomString()
-		clusterReport1 := &configv1alpha1.ClusterReport{
+		clusterReport1 := &configv1beta1.ClusterReport{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ns.Name,
 				Name:      randomString(),
 				Labels: map[string]string{
 					"projectsveltos.io/cluster-profile-name": clusterProfileName1,
 				},
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						Kind:       configv1beta1.ClusterProfileKind,
+						Name:       randomString(),
+						APIVersion: configv1beta1.GroupVersion.String(),
+					},
+				},
 			},
-			Spec: configv1alpha1.ClusterReportSpec{
+			Spec: configv1beta1.ClusterReportSpec{
 				ClusterNamespace: clusterNamespace,
 				ClusterName:      clusterName,
 			},
-			Status: configv1alpha1.ClusterReportStatus{
+			Status: configv1beta1.ClusterReportStatus{
 				ReleaseReports: releaseReports1,
 			},
 		}
 
-		releaseReports2 := []configv1alpha1.ReleaseReport{
-			*generateReleaseReport(string(configv1alpha1.HelmChartActionInstall)),
-			*generateReleaseReport(string(configv1alpha1.HelmChartActionUninstall)),
-			*generateReleaseReport(string(configv1alpha1.NoHelmAction)),
+		releaseReports2 := []configv1beta1.ReleaseReport{
+			*generateReleaseReport(string(configv1beta1.HelmChartActionInstall)),
+			*generateReleaseReport(string(configv1beta1.HelmChartActionUninstall)),
+			*generateReleaseReport(string(configv1beta1.NoHelmAction)),
 		}
 
 		clusterProfileName2 := randomString()
-		clusterReport2 := &configv1alpha1.ClusterReport{
+		clusterReport2 := &configv1beta1.ClusterReport{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ns.Name,
 				Name:      randomString(),
 				Labels: map[string]string{
 					"projectsveltos.io/cluster-profile-name": clusterProfileName2,
 				},
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						Kind:       configv1beta1.ClusterProfileKind,
+						Name:       randomString(),
+						APIVersion: configv1beta1.GroupVersion.String(),
+					},
+				},
 			},
-			Spec: configv1alpha1.ClusterReportSpec{
+			Spec: configv1beta1.ClusterReportSpec{
 				ClusterNamespace: clusterNamespace,
 				ClusterName:      clusterName,
 			},
-			Status: configv1alpha1.ClusterReportStatus{
+			Status: configv1beta1.ClusterReportStatus{
 				ReleaseReports: releaseReports2,
 			},
 		}
@@ -150,50 +164,64 @@ var _ = Describe("DryRun", func() {
 		clusterNamespace := ns.Name
 		clusterName := randomString()
 
-		resourceReports1 := []configv1alpha1.ResourceReport{
-			*generateResourceReport(string(configv1alpha1.HelmChartActionInstall)),
-			*generateResourceReport(string(configv1alpha1.NoHelmAction)),
+		resourceReports1 := []configv1beta1.ResourceReport{
+			*generateResourceReport(string(configv1beta1.HelmChartActionInstall)),
+			*generateResourceReport(string(configv1beta1.NoHelmAction)),
 		}
 
 		clusterProfileName1 := randomString()
-		clusterReport1 := &configv1alpha1.ClusterReport{
+		clusterReport1 := &configv1beta1.ClusterReport{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ns.Name,
 				Name:      randomString(),
 				Labels: map[string]string{
 					"projectsveltos.io/cluster-profile-name": clusterProfileName1,
 				},
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						Kind:       configv1beta1.ClusterProfileKind,
+						Name:       randomString(),
+						APIVersion: configv1beta1.GroupVersion.String(),
+					},
+				},
 			},
-			Spec: configv1alpha1.ClusterReportSpec{
+			Spec: configv1beta1.ClusterReportSpec{
 				ClusterNamespace: clusterNamespace,
 				ClusterName:      clusterName,
 			},
-			Status: configv1alpha1.ClusterReportStatus{
+			Status: configv1beta1.ClusterReportStatus{
 				ResourceReports: resourceReports1,
 			},
 		}
 
-		resourceReports2 := []configv1alpha1.ResourceReport{
-			*generateResourceReport(string(configv1alpha1.CreateResourceAction)),
-			*generateResourceReport(string(configv1alpha1.UpdateResourceAction)),
-			*generateResourceReport(string(configv1alpha1.NoResourceAction)),
-			*generateResourceReport(string(configv1alpha1.DeleteResourceAction)),
+		resourceReports2 := []configv1beta1.ResourceReport{
+			*generateResourceReport(string(configv1beta1.CreateResourceAction)),
+			*generateResourceReport(string(configv1beta1.UpdateResourceAction)),
+			*generateResourceReport(string(configv1beta1.NoResourceAction)),
+			*generateResourceReport(string(configv1beta1.DeleteResourceAction)),
 		}
 
 		clusterProfileName2 := randomString()
-		clusterReport2 := &configv1alpha1.ClusterReport{
+		clusterReport2 := &configv1beta1.ClusterReport{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ns.Name,
 				Name:      randomString(),
 				Labels: map[string]string{
 					"projectsveltos.io/cluster-profile-name": clusterProfileName2,
 				},
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						Kind:       configv1beta1.ClusterProfileKind,
+						Name:       randomString(),
+						APIVersion: configv1beta1.GroupVersion.String(),
+					},
+				},
 			},
-			Spec: configv1alpha1.ClusterReportSpec{
+			Spec: configv1beta1.ClusterReportSpec{
 				ClusterNamespace: clusterNamespace,
 				ClusterName:      clusterName,
 			},
-			Status: configv1alpha1.ClusterReportStatus{
+			Status: configv1beta1.ClusterReportStatus{
 				ResourceReports: resourceReports2,
 			},
 		}
@@ -238,7 +266,7 @@ var _ = Describe("DryRun", func() {
 })
 
 func verifyReleaseReports(lines []string, clusterInfo, clusterProfileName string,
-	releaseReports []configv1alpha1.ReleaseReport) {
+	releaseReports []configv1beta1.ReleaseReport) {
 
 	for i := range releaseReports {
 		verifyReleaseReport(lines, clusterInfo, clusterProfileName, &releaseReports[i])
@@ -246,7 +274,7 @@ func verifyReleaseReports(lines []string, clusterInfo, clusterProfileName string
 }
 
 func verifyReleaseReport(lines []string, clusterInfo, clusterProfileName string,
-	releaseReport *configv1alpha1.ReleaseReport) {
+	releaseReport *configv1beta1.ReleaseReport) {
 
 	found := false
 	for i := range lines {
@@ -269,7 +297,7 @@ func verifyReleaseReport(lines []string, clusterInfo, clusterProfileName string,
 }
 
 func verifyResourceReports(lines []string, clusterInfo, clusterProfileName string,
-	resourceReports []configv1alpha1.ResourceReport) {
+	resourceReports []configv1beta1.ResourceReport) {
 
 	for i := range resourceReports {
 		verifyResourceReport(lines, clusterInfo, clusterProfileName, &resourceReports[i])
@@ -277,7 +305,7 @@ func verifyResourceReports(lines []string, clusterInfo, clusterProfileName strin
 }
 
 func verifyResourceReport(lines []string, clusterInfo, clusterProfileName string,
-	resourceReport *configv1alpha1.ResourceReport) {
+	resourceReport *configv1beta1.ResourceReport) {
 
 	found := false
 	for i := range lines {

--- a/internal/commands/show/usage.go
+++ b/internal/commands/show/usage.go
@@ -28,7 +28,7 @@ import (
 	"github.com/olekukonko/tablewriter"
 	corev1 "k8s.io/api/core/v1"
 
-	configv1alpha1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
 	"github.com/projectsveltos/sveltosctl/internal/utils"
@@ -53,12 +53,12 @@ func showUsage(ctx context.Context, kind, passedNamespace, passedName string, lo
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader([]string{"RESOURCE KIND", "RESOURCE NAMESPACE", "RESOURCE NAME", "CLUSTERS"})
 
-	if kind == "" || kind == configv1alpha1.ClusterProfileKind {
+	if kind == "" || kind == configv1beta1.ClusterProfileKind {
 		if err := showUsageForClusterProfiles(ctx, passedName, table, logger); err != nil {
 			return err
 		}
 	}
-	if kind == "" || kind == configv1alpha1.ProfileKind {
+	if kind == "" || kind == configv1beta1.ProfileKind {
 		if err := showUsageForProfiles(ctx, passedName, table, logger); err != nil {
 			return err
 		}
@@ -106,14 +106,14 @@ func showUsageForClusterProfiles(ctx context.Context, passedName string, table *
 	return nil
 }
 
-func showUsageForClusterProfile(clusterProfile *configv1alpha1.ClusterProfile, table *tablewriter.Table,
+func showUsageForClusterProfile(clusterProfile *configv1beta1.ClusterProfile, table *tablewriter.Table,
 	logger logr.Logger) {
 
 	logger.V(logs.LogDebug).Info(fmt.Sprintf("Considering ClusterProfile %s", clusterProfile.Name))
 
 	clusters := getMatchingClusters(clusterProfile.Status.MatchingClusterRefs)
 
-	table.Append(genUsageRow(configv1alpha1.ClusterProfileKind, "", clusterProfile.Name, clusters))
+	table.Append(genUsageRow(configv1beta1.ClusterProfileKind, "", clusterProfile.Name, clusters))
 }
 
 func showUsageForProfiles(ctx context.Context, passedName string, table *tablewriter.Table, logger logr.Logger) error {
@@ -134,21 +134,21 @@ func showUsageForProfiles(ctx context.Context, passedName string, table *tablewr
 	return nil
 }
 
-func showUsageForProfile(profile *configv1alpha1.Profile, table *tablewriter.Table,
+func showUsageForProfile(profile *configv1beta1.Profile, table *tablewriter.Table,
 	logger logr.Logger) {
 
 	logger.V(logs.LogDebug).Info(fmt.Sprintf("Considering Profile %s", profile.Name))
 
 	clusters := getMatchingClusters(profile.Status.MatchingClusterRefs)
 
-	table.Append(genUsageRow(configv1alpha1.ProfileKind, "", profile.Name, clusters))
+	table.Append(genUsageRow(configv1beta1.ProfileKind, "", profile.Name, clusters))
 }
 
 func showUsageForConfigMaps(ctx context.Context, passedNamespace, passedName string,
 	table *tablewriter.Table, logger logr.Logger) error {
 
 	instance := utils.GetAccessInstance()
-	result := make(map[configv1alpha1.PolicyRef][]string)
+	result := make(map[configv1beta1.PolicyRef][]string)
 
 	cps, err := instance.ListClusterProfiles(ctx, logger)
 	if err != nil {
@@ -186,7 +186,7 @@ func showUsageForSecrets(ctx context.Context, passedNamespace, passedName string
 	table *tablewriter.Table, logger logr.Logger) error {
 
 	instance := utils.GetAccessInstance()
-	result := make(map[configv1alpha1.PolicyRef][]string)
+	result := make(map[configv1beta1.PolicyRef][]string)
 
 	cps, err := instance.ListClusterProfiles(ctx, logger)
 	if err != nil {
@@ -220,10 +220,10 @@ func showUsageForSecrets(ctx context.Context, passedNamespace, passedName string
 	return nil
 }
 
-func getConfigMaps(passedNamespace, passedName string, policyRefs []configv1alpha1.PolicyRef,
-	matchingClusterRefs []corev1.ObjectReference, result map[configv1alpha1.PolicyRef][]string, logger logr.Logger) {
+func getConfigMaps(passedNamespace, passedName string, policyRefs []configv1beta1.PolicyRef,
+	matchingClusterRefs []corev1.ObjectReference, result map[configv1beta1.PolicyRef][]string, logger logr.Logger) {
 
-	configMaps := make([]configv1alpha1.PolicyRef, 0)
+	configMaps := make([]configv1beta1.PolicyRef, 0)
 	for i := range policyRefs {
 		pr := &policyRefs[i]
 		if pr.Kind == string(libsveltosv1beta1.ConfigMapReferencedResourceKind) {
@@ -246,10 +246,10 @@ func getConfigMaps(passedNamespace, passedName string, policyRefs []configv1alph
 	}
 }
 
-func getSecrets(passedNamespace, passedName string, policyRefs []configv1alpha1.PolicyRef,
-	matchingClusterRefs []corev1.ObjectReference, result map[configv1alpha1.PolicyRef][]string, logger logr.Logger) {
+func getSecrets(passedNamespace, passedName string, policyRefs []configv1beta1.PolicyRef,
+	matchingClusterRefs []corev1.ObjectReference, result map[configv1beta1.PolicyRef][]string, logger logr.Logger) {
 
-	secrets := make([]configv1alpha1.PolicyRef, 0)
+	secrets := make([]configv1beta1.PolicyRef, 0)
 	for i := range policyRefs {
 		pr := &policyRefs[i]
 		if pr.Kind == string(libsveltosv1beta1.SecretReferencedResourceKind) {
@@ -272,7 +272,7 @@ func getSecrets(passedNamespace, passedName string, policyRefs []configv1alpha1.
 	}
 }
 
-func shouldAddPolicyRef(passedNamespace, passedName string, pr *configv1alpha1.PolicyRef) bool {
+func shouldAddPolicyRef(passedNamespace, passedName string, pr *configv1beta1.PolicyRef) bool {
 	if passedNamespace != "" &&
 		pr.Namespace != passedNamespace {
 
@@ -344,13 +344,13 @@ Description:
 	kind := ""
 	if passedKind := parsedArgs["--kind"]; passedKind != nil {
 		kind = passedKind.(string)
-		if kind != configv1alpha1.ClusterProfileKind &&
-			kind != configv1alpha1.ProfileKind &&
+		if kind != configv1beta1.ClusterProfileKind &&
+			kind != configv1beta1.ProfileKind &&
 			kind != string(libsveltosv1beta1.ConfigMapReferencedResourceKind) &&
 			kind != string(libsveltosv1beta1.SecretReferencedResourceKind) {
 
 			return fmt.Errorf("possible values for kind are: %s, %s, %s, %s",
-				configv1alpha1.ClusterProfileKind, configv1alpha1.ProfileKind,
+				configv1beta1.ClusterProfileKind, configv1beta1.ProfileKind,
 				string(libsveltosv1beta1.ConfigMapReferencedResourceKind),
 				string(libsveltosv1beta1.SecretReferencedResourceKind),
 			)

--- a/internal/commands/show/usage_test.go
+++ b/internal/commands/show/usage_test.go
@@ -33,7 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2/textlogger"
 
-	configv1alpha1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	"github.com/projectsveltos/sveltosctl/internal/commands/show"
 	"github.com/projectsveltos/sveltosctl/internal/utils"
@@ -41,20 +41,20 @@ import (
 
 var _ = Describe("Usage", func() {
 	It("showUsage displays per resource, associated list of CAPI clusters", func() {
-		configMap := configv1alpha1.PolicyRef{
+		configMap := configv1beta1.PolicyRef{
 			Namespace: randomString(),
 			Name:      randomString(),
 			Kind:      string(libsveltosv1beta1.ConfigMapReferencedResourceKind),
 		}
 
-		secret := configv1alpha1.PolicyRef{
+		secret := configv1beta1.PolicyRef{
 			Namespace: randomString(),
 			Name:      randomString(),
 			Kind:      string(libsveltosv1beta1.SecretReferencedResourceKind),
 		}
 
 		clusterProfile1 := generateClusterProfile()
-		clusterProfile1.Spec.PolicyRefs = []configv1alpha1.PolicyRef{
+		clusterProfile1.Spec.PolicyRefs = []configv1beta1.PolicyRef{
 			configMap,
 		}
 		clusterProfile1.Status.MatchingClusterRefs = []corev1.ObjectReference{
@@ -62,7 +62,7 @@ var _ = Describe("Usage", func() {
 		}
 
 		clusterProfile2 := generateClusterProfile()
-		clusterProfile2.Spec.PolicyRefs = []configv1alpha1.PolicyRef{
+		clusterProfile2.Spec.PolicyRefs = []configv1beta1.PolicyRef{
 			secret,
 		}
 		clusterProfile2.Status.MatchingClusterRefs = []corev1.ObjectReference{
@@ -111,9 +111,9 @@ var _ = Describe("Usage", func() {
 	})
 })
 
-func verifyClusterProfileUsage(lines []string, clusterProfile *configv1alpha1.ClusterProfile) {
+func verifyClusterProfileUsage(lines []string, clusterProfile *configv1beta1.ClusterProfile) {
 	for i := range clusterProfile.Status.MatchingClusterRefs {
-		verifyUsage(lines, configv1alpha1.ClusterProfileKind, "", clusterProfile.Name,
+		verifyUsage(lines, configv1beta1.ClusterProfileKind, "", clusterProfile.Name,
 			&clusterProfile.Status.MatchingClusterRefs[i])
 	}
 }
@@ -133,18 +133,18 @@ func verifyUsage(lines []string, kind, namespace, name string, matchingCluster *
 	Expect(found).To(BeTrue())
 }
 
-func generateClusterProfile() *configv1alpha1.ClusterProfile {
-	return &configv1alpha1.ClusterProfile{
+func generateClusterProfile() *configv1beta1.ClusterProfile {
+	return &configv1beta1.ClusterProfile{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: randomString(),
 		},
-		Spec: configv1alpha1.Spec{
+		Spec: configv1beta1.Spec{
 			ClusterSelector: libsveltosv1beta1.Selector{
 				LabelSelector: metav1.LabelSelector{
 					MatchLabels: map[string]string{"zone": "west"},
 				},
 			},
-			SyncMode: configv1alpha1.SyncModeContinuous,
+			SyncMode: configv1beta1.SyncModeContinuous,
 		},
 	}
 }

--- a/internal/commands/show/utils.go
+++ b/internal/commands/show/utils.go
@@ -19,7 +19,7 @@ package show
 import (
 	corev1 "k8s.io/api/core/v1"
 
-	configv1alpha1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 )
 
 func doConsiderNamespace(ns *corev1.Namespace, passedNamespace string) bool {
@@ -30,7 +30,7 @@ func doConsiderNamespace(ns *corev1.Namespace, passedNamespace string) bool {
 	return ns.Name == passedNamespace
 }
 
-func doConsiderClusterConfiguration(clusterConfiguration *configv1alpha1.ClusterConfiguration,
+func doConsiderClusterConfiguration(clusterConfiguration *configv1beta1.ClusterConfiguration,
 	passedCluster string) bool {
 
 	if passedCluster == "" {
@@ -41,11 +41,11 @@ func doConsiderClusterConfiguration(clusterConfiguration *configv1alpha1.Cluster
 		return false
 	}
 
-	clusterName := clusterConfiguration.Labels[configv1alpha1.ClusterNameLabel]
+	clusterName := clusterConfiguration.Labels[configv1beta1.ClusterNameLabel]
 	return clusterName == passedCluster
 }
 
-func doConsiderClusterReport(clusterReport *configv1alpha1.ClusterReport,
+func doConsiderClusterReport(clusterReport *configv1beta1.ClusterReport,
 	passedCluster string) bool {
 
 	if passedCluster == "" {

--- a/internal/commands/show/utils_test.go
+++ b/internal/commands/show/utils_test.go
@@ -30,27 +30,27 @@ import (
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	configv1alpha1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	"github.com/projectsveltos/sveltosctl/internal/utils"
 )
 
 // addDeployedHelmCharts adds provided charts as deployed in clusterConfiguration status
-func addDeployedHelmCharts(clusterConfiguration *configv1alpha1.ClusterConfiguration,
-	clusterProfileName string, charts []configv1alpha1.Chart) *configv1alpha1.ClusterConfiguration {
+func addDeployedHelmCharts(clusterConfiguration *configv1beta1.ClusterConfiguration,
+	clusterProfileName string, charts []configv1beta1.Chart) *configv1beta1.ClusterConfiguration {
 
 	if clusterConfiguration.Status.ClusterProfileResources == nil {
-		clusterConfiguration.Status.ClusterProfileResources = make([]configv1alpha1.ClusterProfileResource, 0)
+		clusterConfiguration.Status.ClusterProfileResources = make([]configv1beta1.ClusterProfileResource, 0)
 	}
 
 	for i := range clusterConfiguration.Status.ClusterProfileResources {
 		cfr := &clusterConfiguration.Status.ClusterProfileResources[i]
 		if cfr.ClusterProfileName == clusterProfileName {
 			if cfr.Features == nil {
-				cfr.Features = make([]configv1alpha1.Feature, 0)
+				cfr.Features = make([]configv1beta1.Feature, 0)
 			}
 			cfr.Features = append(cfr.Features,
-				configv1alpha1.Feature{
-					FeatureID: configv1alpha1.FeatureHelm,
+				configv1beta1.Feature{
+					FeatureID: configv1beta1.FeatureHelm,
 					Charts:    charts,
 				})
 
@@ -58,10 +58,10 @@ func addDeployedHelmCharts(clusterConfiguration *configv1alpha1.ClusterConfigura
 		}
 	}
 
-	cfr := &configv1alpha1.ClusterProfileResource{
+	cfr := &configv1beta1.ClusterProfileResource{
 		ClusterProfileName: clusterProfileName,
-		Features: []configv1alpha1.Feature{
-			{FeatureID: configv1alpha1.FeatureHelm, Charts: charts},
+		Features: []configv1beta1.Feature{
+			{FeatureID: configv1beta1.FeatureHelm, Charts: charts},
 		},
 	}
 	clusterConfiguration.Status.ClusterProfileResources = append(clusterConfiguration.Status.ClusterProfileResources, *cfr)
@@ -70,22 +70,22 @@ func addDeployedHelmCharts(clusterConfiguration *configv1alpha1.ClusterConfigura
 }
 
 // addDeployedResources adds provided resources as deployed in clusterConfiguration status
-func addDeployedResources(clusterConfiguration *configv1alpha1.ClusterConfiguration,
-	clusterProfileName string, resources []configv1alpha1.Resource) *configv1alpha1.ClusterConfiguration {
+func addDeployedResources(clusterConfiguration *configv1beta1.ClusterConfiguration,
+	clusterProfileName string, resources []configv1beta1.Resource) *configv1beta1.ClusterConfiguration {
 
 	if clusterConfiguration.Status.ClusterProfileResources == nil {
-		clusterConfiguration.Status.ClusterProfileResources = make([]configv1alpha1.ClusterProfileResource, 0)
+		clusterConfiguration.Status.ClusterProfileResources = make([]configv1beta1.ClusterProfileResource, 0)
 	}
 
 	for i := range clusterConfiguration.Status.ClusterProfileResources {
 		cfr := &clusterConfiguration.Status.ClusterProfileResources[i]
 		if cfr.ClusterProfileName == clusterProfileName {
 			if cfr.Features == nil {
-				cfr.Features = make([]configv1alpha1.Feature, 0)
+				cfr.Features = make([]configv1beta1.Feature, 0)
 			}
 			cfr.Features = append(cfr.Features,
-				configv1alpha1.Feature{
-					FeatureID: configv1alpha1.FeatureResources,
+				configv1beta1.Feature{
+					FeatureID: configv1beta1.FeatureResources,
 					Resources: resources,
 				})
 
@@ -93,10 +93,10 @@ func addDeployedResources(clusterConfiguration *configv1alpha1.ClusterConfigurat
 		}
 	}
 
-	cfr := &configv1alpha1.ClusterProfileResource{
+	cfr := &configv1beta1.ClusterProfileResource{
 		ClusterProfileName: clusterProfileName,
-		Features: []configv1alpha1.Feature{
-			{FeatureID: configv1alpha1.FeatureResources, Resources: resources},
+		Features: []configv1beta1.Feature{
+			{FeatureID: configv1beta1.FeatureResources, Resources: resources},
 		},
 	}
 	clusterConfiguration.Status.ClusterProfileResources = append(clusterConfiguration.Status.ClusterProfileResources, *cfr)
@@ -104,9 +104,9 @@ func addDeployedResources(clusterConfiguration *configv1alpha1.ClusterConfigurat
 	return clusterConfiguration
 }
 
-func generateChart() *configv1alpha1.Chart {
+func generateChart() *configv1beta1.Chart {
 	t := metav1.Time{Time: time.Now()}
-	return &configv1alpha1.Chart{
+	return &configv1beta1.Chart{
 		RepoURL:         randomString(),
 		ReleaseName:     randomString(),
 		Namespace:       randomString(),
@@ -115,9 +115,9 @@ func generateChart() *configv1alpha1.Chart {
 	}
 }
 
-func generateResource() *configv1alpha1.Resource {
+func generateResource() *configv1beta1.Resource {
 	t := metav1.Time{Time: time.Now()}
-	return &configv1alpha1.Resource{
+	return &configv1beta1.Resource{
 		Name:            randomString(),
 		Namespace:       randomString(),
 		Group:           randomString(),
@@ -126,8 +126,8 @@ func generateResource() *configv1alpha1.Resource {
 	}
 }
 
-func generateReleaseReport(action string) *configv1alpha1.ReleaseReport {
-	return &configv1alpha1.ReleaseReport{
+func generateReleaseReport(action string) *configv1beta1.ReleaseReport {
+	return &configv1beta1.ReleaseReport{
 		ReleaseName:      randomString(),
 		ReleaseNamespace: randomString(),
 		ChartVersion:     randomString(),
@@ -135,9 +135,9 @@ func generateReleaseReport(action string) *configv1alpha1.ReleaseReport {
 	}
 }
 
-func generateResourceReport(action string) *configv1alpha1.ResourceReport {
-	return &configv1alpha1.ResourceReport{
-		Resource: configv1alpha1.Resource{
+func generateResourceReport(action string) *configv1beta1.ResourceReport {
+	return &configv1beta1.ResourceReport{
+		Resource: configv1beta1.Resource{
 			Name:      randomString(),
 			Namespace: randomString(),
 			Group:     randomString(),

--- a/internal/commands/snapshot/diff.go
+++ b/internal/commands/snapshot/diff.go
@@ -38,7 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2/textlogger"
 
-	configv1alpha1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
 	utilsv1beta1 "github.com/projectsveltos/sveltosctl/api/v1beta1"
@@ -252,7 +252,7 @@ func listSnapshotDiffsBewteenSamples(fromFolder, toFolder, passedNamespace, pass
 	// There is one ClusterConfigurations per Cluster
 	snapshotClient := collector.GetClient()
 	fromClusterConfigurationMap, err := snapshotClient.GetNamespacedResources(fromFolder,
-		configv1alpha1.ClusterConfigurationKind, logger)
+		configv1beta1.ClusterConfigurationKind, logger)
 	if err != nil {
 		logger.V(logs.LogDebug).Info(fmt.Sprintf("failed to collect ClusterConfigurations from folder %s", fromFolder))
 		return err
@@ -261,7 +261,7 @@ func listSnapshotDiffsBewteenSamples(fromFolder, toFolder, passedNamespace, pass
 		len(fromClusterConfigurationMap), fromFolder))
 
 	toClusterConfigurationMap, err := snapshotClient.GetNamespacedResources(toFolder,
-		configv1alpha1.ClusterConfigurationKind, logger)
+		configv1beta1.ClusterConfigurationKind, logger)
 	if err != nil {
 		logger.V(logs.LogDebug).Info(fmt.Sprintf("failed to collect ClusterConfigurations from folder %s", toFolder))
 		return err
@@ -337,17 +337,17 @@ func listFeatureDiffInNamespace(fromFolder, toFolder, namespace string,
 }
 
 func getClusterConfigurationsInNamespace(namespace, passedCluster string, clusterConfigurationMap map[string][]*unstructured.Unstructured,
-	logger logr.Logger) ([]*configv1alpha1.ClusterConfiguration, error) {
+	logger logr.Logger) ([]*configv1beta1.ClusterConfiguration, error) {
 
 	resources, ok := clusterConfigurationMap[namespace]
 	if !ok {
 		return nil, nil
 	}
 
-	results := make([]*configv1alpha1.ClusterConfiguration, 0)
+	results := make([]*configv1beta1.ClusterConfiguration, 0)
 	for i := range resources {
 		resource := resources[i]
-		var clusterConfiguration configv1alpha1.ClusterConfiguration
+		var clusterConfiguration configv1beta1.ClusterConfiguration
 		err := runtime.DefaultUnstructuredConverter.
 			FromUnstructured(resource.UnstructuredContent(), &clusterConfiguration)
 		if err != nil {
@@ -362,17 +362,17 @@ func getClusterConfigurationsInNamespace(namespace, passedCluster string, cluste
 	return results, nil
 }
 
-func listDiffInClusterConfigurations(fromFolder, toFolder string, fromClusterConfigurations, toClusterConfigurations []*configv1alpha1.ClusterConfiguration,
+func listDiffInClusterConfigurations(fromFolder, toFolder string, fromClusterConfigurations, toClusterConfigurations []*configv1beta1.ClusterConfiguration,
 	rawDiff bool, table *tablewriter.Table, logger logr.Logger) error {
 
 	// Create maps
-	fromClusterConfigurationMaps := make(map[string]*configv1alpha1.ClusterConfiguration)
+	fromClusterConfigurationMaps := make(map[string]*configv1beta1.ClusterConfiguration)
 	for i := range fromClusterConfigurations {
 		cc := fromClusterConfigurations[i]
 		fromClusterConfigurationMaps[cc.Name] = cc
 	}
 
-	toClusterConfigurationMaps := make(map[string]*configv1alpha1.ClusterConfiguration)
+	toClusterConfigurationMaps := make(map[string]*configv1beta1.ClusterConfiguration)
 	for i := range toClusterConfigurations {
 		cc := toClusterConfigurations[i]
 		toClusterConfigurationMaps[cc.Name] = cc
@@ -397,11 +397,11 @@ func listDiffInClusterConfigurations(fromFolder, toFolder string, fromClusterCon
 	return nil
 }
 
-func listClusterConfigurationDiff(fromFolder, toFolder string, fromClusterConfiguration, toClusterConfiguration *configv1alpha1.ClusterConfiguration,
+func listClusterConfigurationDiff(fromFolder, toFolder string, fromClusterConfiguration, toClusterConfiguration *configv1beta1.ClusterConfiguration,
 	rawDiff bool, table *tablewriter.Table, logger logr.Logger) error {
 
-	toCharts := make([]configv1alpha1.Chart, 0)
-	toResources := make([]configv1alpha1.Resource, 0)
+	toCharts := make([]configv1beta1.Chart, 0)
+	toResources := make([]configv1beta1.Resource, 0)
 	if toClusterConfiguration != nil {
 		for i := range toClusterConfiguration.Status.ClusterProfileResources {
 			cpr := &toClusterConfiguration.Status.ClusterProfileResources[i]
@@ -413,8 +413,8 @@ func listClusterConfigurationDiff(fromFolder, toFolder string, fromClusterConfig
 		}
 	}
 
-	fromCharts := make([]configv1alpha1.Chart, 0)
-	fromResources := make([]configv1alpha1.Resource, 0)
+	fromCharts := make([]configv1beta1.Chart, 0)
+	fromResources := make([]configv1beta1.Resource, 0)
 	if fromClusterConfiguration != nil {
 		for i := range fromClusterConfiguration.Status.ClusterProfileResources {
 			cpr := &fromClusterConfiguration.Status.ClusterProfileResources[i]
@@ -446,11 +446,11 @@ func listClusterConfigurationDiff(fromFolder, toFolder string, fromClusterConfig
 	return nil
 }
 
-func addChartEntry(fromClusterConfiguration, toClusterConfiguration *configv1alpha1.ClusterConfiguration,
-	charts []*configv1alpha1.Chart, action string, message map[configv1alpha1.Chart]string, table *tablewriter.Table) {
+func addChartEntry(fromClusterConfiguration, toClusterConfiguration *configv1beta1.ClusterConfiguration,
+	charts []*configv1beta1.Chart, action string, message map[configv1beta1.Chart]string, table *tablewriter.Table) {
 
 	instance := utils.GetAccessInstance()
-	clusterInfo := func(fromClusterConfiguration, toClusterConfiguration *configv1alpha1.ClusterConfiguration) string {
+	clusterInfo := func(fromClusterConfiguration, toClusterConfiguration *configv1beta1.ClusterConfiguration) string {
 		if toClusterConfiguration != nil {
 			clusterName := instance.GetClusterNameFromClusterConfiguration(toClusterConfiguration)
 			return fmt.Sprintf("%s/%s", toClusterConfiguration.Namespace, clusterName)
@@ -473,11 +473,11 @@ func addChartEntry(fromClusterConfiguration, toClusterConfiguration *configv1alp
 	}
 }
 
-func addResourceEntry(fromClusterConfiguration, toClusterConfiguration *configv1alpha1.ClusterConfiguration,
-	resources []*configv1alpha1.Resource, action, msg string,
+func addResourceEntry(fromClusterConfiguration, toClusterConfiguration *configv1beta1.ClusterConfiguration,
+	resources []*configv1beta1.Resource, action, msg string,
 	table *tablewriter.Table) {
 
-	clusterInfo := func(fromClusterConfiguration, toClusterConfiguration *configv1alpha1.ClusterConfiguration) string {
+	clusterInfo := func(fromClusterConfiguration, toClusterConfiguration *configv1beta1.ClusterConfiguration) string {
 		if toClusterConfiguration != nil {
 			return fmt.Sprintf("%s/%s", toClusterConfiguration.Namespace, toClusterConfiguration.Name)
 		}
@@ -494,22 +494,22 @@ func addResourceEntry(fromClusterConfiguration, toClusterConfiguration *configv1
 }
 
 // chartDifference returns differences between from and to
-func chartDifference(from, to []configv1alpha1.Chart) (added, modified, deleted []*configv1alpha1.Chart,
-	modifiedMessage map[configv1alpha1.Chart]string) {
+func chartDifference(from, to []configv1beta1.Chart) (added, modified, deleted []*configv1beta1.Chart,
+	modifiedMessage map[configv1beta1.Chart]string) {
 
-	modifiedMessage = make(map[configv1alpha1.Chart]string)
+	modifiedMessage = make(map[configv1beta1.Chart]string)
 
-	chartInfo := func(chart *configv1alpha1.Chart) string {
+	chartInfo := func(chart *configv1beta1.Chart) string {
 		return fmt.Sprintf("%s/%s", chart.Namespace, chart.ReleaseName)
 	}
 
-	toChartMap := make(map[string]*configv1alpha1.Chart, len(to))
+	toChartMap := make(map[string]*configv1beta1.Chart, len(to))
 	for i := range to {
 		chart := &to[i]
 		toChartMap[chartInfo(chart)] = chart
 	}
 
-	fromChartMap := make(map[string]*configv1alpha1.Chart, len(from))
+	fromChartMap := make(map[string]*configv1beta1.Chart, len(from))
 	for i := range from {
 		chart := &from[i]
 		fromChartMap[chartInfo(chart)] = chart
@@ -538,28 +538,28 @@ func chartDifference(from, to []configv1alpha1.Chart) (added, modified, deleted 
 }
 
 // resourceDifference returns differences between from and to
-func resourceDifference(fromFolder, toFolder string, from, to []configv1alpha1.Resource, rawDiff bool,
-	logger logr.Logger) (added, modified, deleted []*configv1alpha1.Resource, err error) {
+func resourceDifference(fromFolder, toFolder string, from, to []configv1beta1.Resource, rawDiff bool,
+	logger logr.Logger) (added, modified, deleted []*configv1beta1.Resource, err error) {
 
-	resourceInfo := func(resource *configv1alpha1.Resource) string {
+	resourceInfo := func(resource *configv1beta1.Resource) string {
 		return fmt.Sprintf("%s:%s:%s/%s", resource.Group, resource.Kind, resource.Namespace, resource.Name)
 	}
 
-	toResourceMap := make(map[string]*configv1alpha1.Resource, len(to))
+	toResourceMap := make(map[string]*configv1beta1.Resource, len(to))
 	for i := range to {
 		resource := &to[i]
 		toResourceMap[resourceInfo(resource)] = resource
 	}
 
-	fromResourceMap := make(map[string]*configv1alpha1.Resource, len(from))
+	fromResourceMap := make(map[string]*configv1beta1.Resource, len(from))
 	for i := range from {
 		resource := &from[i]
 		fromResourceMap[resourceInfo(resource)] = resource
 	}
 
-	var addedResources []*configv1alpha1.Resource
-	var deletedResources []*configv1alpha1.Resource
-	var modifiedResources []*configv1alpha1.Resource
+	var addedResources []*configv1beta1.Resource
+	var deletedResources []*configv1beta1.Resource
+	var modifiedResources []*configv1beta1.Resource
 
 	for k := range toResourceMap {
 		logger.V(logs.LogDebug).Info(fmt.Sprintf("analyzing resource %s/%s %s/%s",
@@ -591,8 +591,8 @@ func resourceDifference(fromFolder, toFolder string, from, to []configv1alpha1.R
 	return addedResources, modifiedResources, deletedResources, nil
 }
 
-func appendChartsAndResourcesForClusterProfiles(cpr *configv1alpha1.ClusterProfileResource, charts []configv1alpha1.Chart,
-	resources []configv1alpha1.Resource) ([]configv1alpha1.Chart, []configv1alpha1.Resource) {
+func appendChartsAndResourcesForClusterProfiles(cpr *configv1beta1.ClusterProfileResource, charts []configv1beta1.Chart,
+	resources []configv1beta1.Resource) ([]configv1beta1.Chart, []configv1beta1.Resource) {
 
 	for i := range cpr.Features {
 		for j := range cpr.Features[i].Charts {
@@ -606,8 +606,8 @@ func appendChartsAndResourcesForClusterProfiles(cpr *configv1alpha1.ClusterProfi
 	return charts, resources
 }
 
-func appendChartsAndResourcesForProfiles(pr *configv1alpha1.ProfileResource, charts []configv1alpha1.Chart,
-	resources []configv1alpha1.Resource) ([]configv1alpha1.Chart, []configv1alpha1.Resource) {
+func appendChartsAndResourcesForProfiles(pr *configv1beta1.ProfileResource, charts []configv1beta1.Chart,
+	resources []configv1beta1.Resource) ([]configv1beta1.Chart, []configv1beta1.Resource) {
 
 	for i := range pr.Features {
 		for j := range pr.Features[i].Charts {
@@ -622,7 +622,7 @@ func appendChartsAndResourcesForProfiles(pr *configv1alpha1.ProfileResource, cha
 }
 
 // hasDiff returns true if any diff exist
-func hasDiff(fromFolder, toFolder string, from, to *configv1alpha1.Resource, rawDiff bool) (bool, error) {
+func hasDiff(fromFolder, toFolder string, from, to *configv1beta1.Resource, rawDiff bool) (bool, error) {
 	fromResource, err := getResourceFromResourceOwner(fromFolder, from)
 	if err != nil {
 		return false, err
@@ -692,7 +692,7 @@ func hasResourceDiff(from, to *unstructured.Unstructured, rawDiff bool, logger l
 	return false, nil
 }
 
-func getResourceFromResourceOwner(folder string, resource *configv1alpha1.Resource) (string, error) {
+func getResourceFromResourceOwner(folder string, resource *configv1beta1.Resource) (string, error) {
 	ownerPath := buildOwnerPath(folder, resource)
 
 	owner, err := getResourceOwner(ownerPath)
@@ -745,7 +745,7 @@ func getResourceFromResourceOwner(folder string, resource *configv1alpha1.Resour
 		resource.Kind, resource.Namespace, resource.Name, ownerPath)
 }
 
-func buildOwnerPath(folder string, resource *configv1alpha1.Resource) string {
+func buildOwnerPath(folder string, resource *configv1beta1.Resource) string {
 	return filepath.Join(folder,
 		resource.Owner.Namespace,
 		resource.Owner.Kind,

--- a/internal/commands/snapshot/diff_test.go
+++ b/internal/commands/snapshot/diff_test.go
@@ -39,7 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	configv1alpha1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	utilsv1beta1 "github.com/projectsveltos/sveltosctl/api/v1beta1"
 	"github.com/projectsveltos/sveltosctl/internal/collector"
@@ -325,7 +325,7 @@ var _ = Describe("Snapshot Diff", func() {
 
 	It("listFeaturesDiffInCluster list differences in collected ClusterConfigurations", func() {
 		newClusterConfiguration := generateClusterConfiguration()
-		oldClusterConfiguration := &configv1alpha1.ClusterConfiguration{
+		oldClusterConfiguration := &configv1beta1.ClusterConfiguration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      newClusterConfiguration.Name,
 				Namespace: newClusterConfiguration.Namespace,
@@ -333,8 +333,8 @@ var _ = Describe("Snapshot Diff", func() {
 		}
 		table := tablewriter.NewWriter(os.Stdout)
 		Expect(snapshot.ListDiffInClusterConfigurations("", "",
-			[]*configv1alpha1.ClusterConfiguration{oldClusterConfiguration},
-			[]*configv1alpha1.ClusterConfiguration{newClusterConfiguration},
+			[]*configv1beta1.ClusterConfiguration{oldClusterConfiguration},
+			[]*configv1beta1.ClusterConfiguration{newClusterConfiguration},
 			false, table, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(Succeed())
 
 		result := fmt.Sprintf("table: %v\n", table)
@@ -346,12 +346,12 @@ var _ = Describe("Snapshot Diff", func() {
 	It("listClusterConfigurationDiff list differences between two ClusterConfigurations", func() {
 		newClusterConfiguration := generateClusterConfiguration()
 		newClusterConfiguration.Status.ClusterProfileResources =
-			[]configv1alpha1.ClusterProfileResource{
+			[]configv1beta1.ClusterProfileResource{
 				*generateClusterProfileResource(),
 				*generateClusterProfileResource(),
 			}
 
-		oldClusterConfiguration := &configv1alpha1.ClusterConfiguration{
+		oldClusterConfiguration := &configv1beta1.ClusterConfiguration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      newClusterConfiguration.Name,
 				Namespace: newClusterConfiguration.Namespace,
@@ -369,8 +369,8 @@ var _ = Describe("Snapshot Diff", func() {
 	})
 
 	It("chartDifference lists added and deleted charts between two slices of charts", func() {
-		oldCharts := []configv1alpha1.Chart{*generateChart()}
-		newCharts := []configv1alpha1.Chart{*generateChart()}
+		oldCharts := []configv1beta1.Chart{*generateChart()}
+		newCharts := []configv1beta1.Chart{*generateChart()}
 
 		added, modified, deleted, message := snapshot.ChartDifference(oldCharts, newCharts)
 		Expect(len(added)).To(Equal(1))
@@ -381,10 +381,10 @@ var _ = Describe("Snapshot Diff", func() {
 
 	It("chartDifference lists modifed charts between two slices of charts", func() {
 		chart := generateChart()
-		oldCharts := []configv1alpha1.Chart{*chart}
+		oldCharts := []configv1beta1.Chart{*chart}
 		newChart := *chart
 		newChart.ChartVersion = randomString()
-		newCharts := []configv1alpha1.Chart{newChart}
+		newCharts := []configv1beta1.Chart{newChart}
 
 		added, modified, deleted, message := snapshot.ChartDifference(oldCharts, newCharts)
 		Expect(len(added)).To(Equal(0))
@@ -397,8 +397,8 @@ var _ = Describe("Snapshot Diff", func() {
 	})
 
 	It("resourceDifference lists added and delete resources between two slices of resources", func() {
-		oldResources := []configv1alpha1.Resource{*generateResource()}
-		newResources := []configv1alpha1.Resource{*generateResource(), *generateResource()}
+		oldResources := []configv1beta1.Resource{*generateResource()}
+		newResources := []configv1beta1.Resource{*generateResource(), *generateResource()}
 
 		added, modified, deleted, err :=
 			snapshot.ResourceDifference("", "", oldResources, newResources, false,
@@ -437,7 +437,7 @@ var _ = Describe("Snapshot Diff", func() {
 		Expect(collectorClient.DumpObject(newConfigMap, newFolder,
 			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(Succeed())
 
-		oldResource := &configv1alpha1.Resource{
+		oldResource := &configv1beta1.Resource{
 			Kind:            "ClusterRole",
 			Name:            clusterRole.GetName(),
 			LastAppliedTime: &metav1.Time{Time: time.Now()},
@@ -452,8 +452,8 @@ var _ = Describe("Snapshot Diff", func() {
 		newResource.LastAppliedTime = &metav1.Time{Time: time.Now().Add(time.Second * time.Duration(2))}
 
 		added, modified, deleted, err :=
-			snapshot.ResourceDifference(oldFolder, newFolder, []configv1alpha1.Resource{*oldResource},
-				[]configv1alpha1.Resource{newResource}, false,
+			snapshot.ResourceDifference(oldFolder, newFolder, []configv1beta1.Resource{*oldResource},
+				[]configv1beta1.Resource{newResource}, false,
 				textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
 		Expect(err).To(BeNil())
 		Expect(len(added)).To(Equal(0))
@@ -462,14 +462,14 @@ var _ = Describe("Snapshot Diff", func() {
 	})
 
 	It("addChartEntry adds chart entries to table", func() {
-		clusterConfiguration := &configv1alpha1.ClusterConfiguration{
+		clusterConfiguration := &configv1beta1.ClusterConfiguration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      randomString(),
 				Namespace: randomString(),
 			},
 		}
 
-		charts := make([]*configv1alpha1.Chart, 0)
+		charts := make([]*configv1beta1.Chart, 0)
 		charts = append(charts, generateChart())
 		charts = append(charts, generateChart())
 
@@ -485,14 +485,14 @@ var _ = Describe("Snapshot Diff", func() {
 	})
 
 	It("addResourceEntry adds resource entries to table", func() {
-		clusterConfiguration := &configv1alpha1.ClusterConfiguration{
+		clusterConfiguration := &configv1beta1.ClusterConfiguration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      randomString(),
 				Namespace: randomString(),
 			},
 		}
 
-		resources := make([]*configv1alpha1.Resource, 0)
+		resources := make([]*configv1beta1.Resource, 0)
 		resources = append(resources, generateResource())
 		resources = append(resources, generateResource())
 
@@ -525,8 +525,8 @@ var _ = Describe("Snapshot Diff", func() {
 		Expect(chartNumber).ToNot(BeZero())
 		Expect(resourceNumber).ToNot(BeZero())
 
-		charts := make([]configv1alpha1.Chart, 0)
-		resources := make([]configv1alpha1.Resource, 0)
+		charts := make([]configv1beta1.Chart, 0)
+		resources := make([]configv1beta1.Resource, 0)
 		charts, resources = snapshot.AppendChartsAndResourcesForClusterProfiles(cpr, charts, resources)
 
 		Expect(len(charts)).To(Equal(chartNumber))
@@ -557,7 +557,7 @@ var _ = Describe("Snapshot Diff", func() {
 
 		clusterRoleGroup := "rbac.authorization.k8s.io/v1"
 		clusterRoleKind := "ClusterRole"
-		resource := &configv1alpha1.Resource{
+		resource := &configv1beta1.Resource{
 			Name:  clusterRole.Name,
 			Group: clusterRoleGroup,
 			Kind:  clusterRoleKind,
@@ -576,9 +576,9 @@ var _ = Describe("Snapshot Diff", func() {
 	})
 })
 
-func generateChart() *configv1alpha1.Chart {
+func generateChart() *configv1beta1.Chart {
 	t := metav1.Time{Time: time.Now()}
-	return &configv1alpha1.Chart{
+	return &configv1beta1.Chart{
 		RepoURL:         randomString(),
 		ReleaseName:     randomString(),
 		Namespace:       randomString(),
@@ -587,9 +587,9 @@ func generateChart() *configv1alpha1.Chart {
 	}
 }
 
-func generateResource() *configv1alpha1.Resource {
+func generateResource() *configv1beta1.Resource {
 	t := metav1.Time{Time: time.Now()}
-	return &configv1alpha1.Resource{
+	return &configv1beta1.Resource{
 		Name:            randomString(),
 		Namespace:       randomString(),
 		Group:           randomString(),
@@ -603,36 +603,36 @@ func generateResource() *configv1alpha1.Resource {
 	}
 }
 
-func generateClusterConfiguration() *configv1alpha1.ClusterConfiguration {
-	return &configv1alpha1.ClusterConfiguration{
+func generateClusterConfiguration() *configv1beta1.ClusterConfiguration {
+	return &configv1beta1.ClusterConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      randomString(),
 			Namespace: randomString(),
 		},
-		Status: configv1alpha1.ClusterConfigurationStatus{
-			ClusterProfileResources: []configv1alpha1.ClusterProfileResource{
+		Status: configv1beta1.ClusterConfigurationStatus{
+			ClusterProfileResources: []configv1beta1.ClusterProfileResource{
 				*generateClusterProfileResource(),
 			},
-			ProfileResources: []configv1alpha1.ProfileResource{
+			ProfileResources: []configv1beta1.ProfileResource{
 				*generateProfileResource(),
 			},
 		},
 	}
 }
 
-func generateClusterProfileResource() *configv1alpha1.ClusterProfileResource {
-	return &configv1alpha1.ClusterProfileResource{
+func generateClusterProfileResource() *configv1beta1.ClusterProfileResource {
+	return &configv1beta1.ClusterProfileResource{
 		ClusterProfileName: randomString(),
-		Features: []configv1alpha1.Feature{
+		Features: []configv1beta1.Feature{
 			{
-				FeatureID: configv1alpha1.FeatureHelm,
-				Charts: []configv1alpha1.Chart{
+				FeatureID: configv1beta1.FeatureHelm,
+				Charts: []configv1beta1.Chart{
 					*generateChart(), *generateChart(),
 				},
 			},
 			{
-				FeatureID: configv1alpha1.FeatureResources,
-				Resources: []configv1alpha1.Resource{
+				FeatureID: configv1beta1.FeatureResources,
+				Resources: []configv1beta1.Resource{
 					*generateResource(), *generateResource(),
 				},
 			},
@@ -640,19 +640,19 @@ func generateClusterProfileResource() *configv1alpha1.ClusterProfileResource {
 	}
 }
 
-func generateProfileResource() *configv1alpha1.ProfileResource {
-	return &configv1alpha1.ProfileResource{
+func generateProfileResource() *configv1beta1.ProfileResource {
+	return &configv1beta1.ProfileResource{
 		ProfileName: randomString(),
-		Features: []configv1alpha1.Feature{
+		Features: []configv1beta1.Feature{
 			{
-				FeatureID: configv1alpha1.FeatureHelm,
-				Charts: []configv1alpha1.Chart{
+				FeatureID: configv1beta1.FeatureHelm,
+				Charts: []configv1beta1.Chart{
 					*generateChart(), *generateChart(),
 				},
 			},
 			{
-				FeatureID: configv1alpha1.FeatureResources,
-				Resources: []configv1alpha1.Resource{
+				FeatureID: configv1beta1.FeatureResources,
+				Resources: []configv1beta1.Resource{
 					*generateResource(), *generateResource(),
 				},
 			},
@@ -660,7 +660,7 @@ func generateProfileResource() *configv1alpha1.ProfileResource {
 	}
 }
 
-func verifyChartAndResources(result string, cpr configv1alpha1.ClusterProfileResource) {
+func verifyChartAndResources(result string, cpr configv1beta1.ClusterProfileResource) {
 	for i := range cpr.Features {
 		if cpr.Features[i].Charts != nil {
 			verifyCharts(result, cpr.Features[i].Charts)
@@ -671,13 +671,13 @@ func verifyChartAndResources(result string, cpr configv1alpha1.ClusterProfileRes
 	}
 }
 
-func verifyCharts(result string, charts []configv1alpha1.Chart) {
+func verifyCharts(result string, charts []configv1beta1.Chart) {
 	for i := range charts {
 		verifyChart(result, &charts[i])
 	}
 }
 
-func verifyChart(result string, chart *configv1alpha1.Chart) {
+func verifyChart(result string, chart *configv1beta1.Chart) {
 	found := false
 	lines := strings.Split(result, "\n")
 	for i := range lines {
@@ -692,13 +692,13 @@ func verifyChart(result string, chart *configv1alpha1.Chart) {
 	Expect(found).To(BeTrue())
 }
 
-func verifyResources(result string, resources []configv1alpha1.Resource) {
+func verifyResources(result string, resources []configv1beta1.Resource) {
 	for i := range resources {
 		verifyResource(result, &resources[i])
 	}
 }
 
-func verifyResource(result string, resources *configv1alpha1.Resource) {
+func verifyResource(result string, resources *configv1beta1.Resource) {
 	found := false
 	lines := strings.Split(result, "\n")
 	for i := range lines {

--- a/internal/commands/snapshot/rollback.go
+++ b/internal/commands/snapshot/rollback.go
@@ -34,7 +34,7 @@ import (
 	"k8s.io/klog/v2/textlogger"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
-	configv1alpha1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
 	utilsv1beta1 "github.com/projectsveltos/sveltosctl/api/v1beta1"
@@ -221,7 +221,7 @@ func getAndRollbackSveltosClusters(ctx context.Context, folder, passedNamespace,
 
 func getAndRollbackProfiles(ctx context.Context, folder, passedNamespace, passedProfile string, logger logr.Logger) error {
 	snapshotClient := collector.GetClient()
-	clusterProfiles, err := snapshotClient.GetClusterResources(folder, configv1alpha1.ClusterProfileKind, logger)
+	clusterProfiles, err := snapshotClient.GetClusterResources(folder, configv1beta1.ClusterProfileKind, logger)
 	if err != nil {
 		logger.V(logs.LogDebug).Info(fmt.Sprintf("failed to collect ClusterProfile from folder %s", folder))
 		return err
@@ -238,7 +238,7 @@ func getAndRollbackProfiles(ctx context.Context, folder, passedNamespace, passed
 		}
 	}
 
-	profiles, err := snapshotClient.GetNamespacedResources(folder, configv1alpha1.ProfileKind, logger)
+	profiles, err := snapshotClient.GetNamespacedResources(folder, configv1beta1.ProfileKind, logger)
 	if err != nil {
 		logger.V(logs.LogDebug).Info(fmt.Sprintf("failed to collect Profile from folder %s", folder))
 		return err
@@ -502,7 +502,7 @@ func rollbackSveltosCluster(ctx context.Context, resource *unstructured.Unstruct
 func rollbackClusterProfile(ctx context.Context, resource *unstructured.Unstructured, logger logr.Logger) error {
 	instance := utils.GetAccessInstance()
 
-	currentClusterProfile := &configv1alpha1.ClusterProfile{}
+	currentClusterProfile := &configv1beta1.ClusterProfile{}
 	err := instance.GetResource(ctx,
 		types.NamespacedName{Name: resource.GetName()}, currentClusterProfile)
 	if err != nil {
@@ -514,7 +514,7 @@ func rollbackClusterProfile(ctx context.Context, resource *unstructured.Unstruct
 		return err
 	}
 
-	passedClusterProfile := &configv1alpha1.ClusterProfile{}
+	passedClusterProfile := &configv1beta1.ClusterProfile{}
 	err = runtime.DefaultUnstructuredConverter.
 		FromUnstructured(resource.UnstructuredContent(), passedClusterProfile)
 	if err != nil {
@@ -534,7 +534,7 @@ func rollbackClusterProfile(ctx context.Context, resource *unstructured.Unstruct
 func rollbackProfile(ctx context.Context, resource *unstructured.Unstructured, logger logr.Logger) error {
 	instance := utils.GetAccessInstance()
 
-	currentProfile := &configv1alpha1.Profile{}
+	currentProfile := &configv1beta1.Profile{}
 	err := instance.GetResource(ctx,
 		types.NamespacedName{Namespace: resource.GetNamespace(), Name: resource.GetName()},
 		currentProfile)
@@ -547,7 +547,7 @@ func rollbackProfile(ctx context.Context, resource *unstructured.Unstructured, l
 		return err
 	}
 
-	passedProfile := &configv1alpha1.Profile{}
+	passedProfile := &configv1beta1.Profile{}
 	err = runtime.DefaultUnstructuredConverter.
 		FromUnstructured(resource.UnstructuredContent(), passedProfile)
 	if err != nil {

--- a/internal/commands/snapshot/rollback_test.go
+++ b/internal/commands/snapshot/rollback_test.go
@@ -35,7 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	configv1alpha1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	"github.com/projectsveltos/sveltosctl/internal/collector"
 	"github.com/projectsveltos/sveltosctl/internal/commands/snapshot"
@@ -231,7 +231,7 @@ var _ = Describe("Snapshot Rollback", func() {
 
 		instance := utils.GetAccessInstance()
 
-		currentCP := &configv1alpha1.ClusterProfile{}
+		currentCP := &configv1beta1.ClusterProfile{}
 		Expect(instance.GetResource(context.TODO(),
 			types.NamespacedName{Name: name}, currentCP)).To(Succeed())
 
@@ -334,7 +334,7 @@ var _ = Describe("Snapshot Rollback", func() {
 			originalClusterLabels[k] = currentCluster.Labels[k]
 		}
 
-		currentClusterProfile := &configv1alpha1.ClusterProfile{}
+		currentClusterProfile := &configv1beta1.ClusterProfile{}
 		Expect(instance.GetResource(context.TODO(),
 			types.NamespacedName{Name: name}, currentClusterProfile)).To(Succeed())
 
@@ -415,7 +415,7 @@ var _ = Describe("Snapshot Rollback", func() {
 		Expect(snapshot.GetAndRollbackProfiles(context.TODO(), folder, "", "",
 			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(Succeed())
 
-		currentClusterProfile := &configv1alpha1.ClusterProfile{}
+		currentClusterProfile := &configv1beta1.ClusterProfile{}
 		Expect(c.Get(context.TODO(),
 			types.NamespacedName{Name: name}, currentClusterProfile)).To(Succeed())
 	})
@@ -488,10 +488,10 @@ func updateClusterLabels(currentCluster *clusterv1.Cluster) {
 	Expect(instance.UpdateResource(context.TODO(), currentCluster)).To(Succeed())
 }
 
-func updateClusterProfileSpec(currentClusterProfile *configv1alpha1.ClusterProfile) {
+func updateClusterProfileSpec(currentClusterProfile *configv1beta1.ClusterProfile) {
 	instance := utils.GetAccessInstance()
 
-	currentClusterProfile.Spec.SyncMode = configv1alpha1.SyncModeDryRun
+	currentClusterProfile.Spec.SyncMode = configv1beta1.SyncModeDryRun
 	currentClusterProfile.Spec.HelmCharts = nil
 	Expect(instance.UpdateResource(context.TODO(), currentClusterProfile)).To(Succeed())
 }

--- a/internal/commands/snapshot_reconciler_utils.go
+++ b/internal/commands/snapshot_reconciler_utils.go
@@ -30,7 +30,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	configv1alpha1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
 	utilsv1beta1 "github.com/projectsveltos/sveltosctl/api/v1beta1"
@@ -436,7 +436,7 @@ func updateSnaphotPredicate(newObject, oldObject *utilsv1beta1.Snapshot) bool {
 	return false
 }
 
-func convertConfigPolicyRefsToLibsveltosPolicyRefs(input []configv1alpha1.PolicyRef) []libsveltosv1beta1.PolicyRef {
+func convertConfigPolicyRefsToLibsveltosPolicyRefs(input []configv1beta1.PolicyRef) []libsveltosv1beta1.PolicyRef {
 	policyRefs := make([]libsveltosv1beta1.PolicyRef, len(input))
 
 	for i := range input {

--- a/internal/utils/client.go
+++ b/internal/utils/client.go
@@ -36,7 +36,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	configv1alpha1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	eventv1beta1 "github.com/projectsveltos/event-manager/api/v1beta1"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
@@ -92,7 +92,7 @@ func addToScheme(scheme *runtime.Scheme) error {
 	if err := appsv1.AddToScheme(scheme); err != nil {
 		return err
 	}
-	if err := configv1alpha1.AddToScheme(scheme); err != nil {
+	if err := configv1beta1.AddToScheme(scheme); err != nil {
 		return err
 	}
 	if err := utilsv1beta1.AddToScheme(scheme); err != nil {

--- a/internal/utils/clusterconfigurations.go
+++ b/internal/utils/clusterconfigurations.go
@@ -24,14 +24,14 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	configv1alpha1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
 )
 
-func (a *k8sAccess) GetClusterNameFromClusterConfiguration(clusterConfiguration *configv1alpha1.ClusterConfiguration) string {
+func (a *k8sAccess) GetClusterNameFromClusterConfiguration(clusterConfiguration *configv1beta1.ClusterConfiguration) string {
 	clusterName := clusterConfiguration.Name
 	if clusterConfiguration.Labels != nil {
-		if v, ok := clusterConfiguration.Labels[configv1alpha1.ClusterNameLabel]; ok {
+		if v, ok := clusterConfiguration.Labels[configv1beta1.ClusterNameLabel]; ok {
 			clusterName = v
 		}
 	}
@@ -40,76 +40,76 @@ func (a *k8sAccess) GetClusterNameFromClusterConfiguration(clusterConfiguration 
 
 // ListClusterConfigurations returns all current ClusterConfigurations in a namespace (if specified)
 func (a *k8sAccess) ListClusterConfigurations(ctx context.Context, namespace string,
-	logger logr.Logger) (*configv1alpha1.ClusterConfigurationList, error) {
+	logger logr.Logger) (*configv1beta1.ClusterConfigurationList, error) {
 
 	listOptions := []client.ListOption{
 		client.InNamespace(namespace),
 	}
 
 	logger.V(logs.LogDebug).Info("Get all ClusterConfigurations")
-	clusterConfigurations := &configv1alpha1.ClusterConfigurationList{}
+	clusterConfigurations := &configv1beta1.ClusterConfigurationList{}
 	err := a.client.List(ctx, clusterConfigurations, listOptions...)
 	return clusterConfigurations, err
 }
 
 // GetClusterConfiguration returns current ClusterConfiguration for a given Cluster
 func (a *k8sAccess) GetClusterConfiguration(ctx context.Context,
-	clusterNamespace, clusterName string, logger logr.Logger) (*configv1alpha1.ClusterConfiguration, error) {
+	clusterNamespace, clusterName string, logger logr.Logger) (*configv1beta1.ClusterConfiguration, error) {
 
 	logger = logger.WithValues("namespace", clusterNamespace, "cluster", clusterName)
 	logger.V(logs.LogDebug).Info("Get ClusterConfiguration")
-	clusterConfiguration := &configv1alpha1.ClusterConfiguration{}
+	clusterConfiguration := &configv1beta1.ClusterConfiguration{}
 	err := a.client.Get(ctx, types.NamespacedName{Namespace: clusterNamespace, Name: clusterName},
 		clusterConfiguration)
 	return clusterConfiguration, err
 }
 
 // GetHelmReleases returns list of helm releases deployed in a given cluster
-func (a *k8sAccess) GetHelmReleases(clusterConfiguration *configv1alpha1.ClusterConfiguration,
-	logger logr.Logger) map[configv1alpha1.Chart][]string {
+func (a *k8sAccess) GetHelmReleases(clusterConfiguration *configv1beta1.ClusterConfiguration,
+	logger logr.Logger) map[configv1beta1.Chart][]string {
 
 	logger = logger.WithValues("namespace", clusterConfiguration.Namespace,
 		"clusterConfiguration", clusterConfiguration.Name)
 
-	results := make(map[configv1alpha1.Chart][]string)
+	results := make(map[configv1beta1.Chart][]string)
 
 	logger.V(logs.LogDebug).Info("Get Helm Releases deployed in the cluster")
 	for i := range clusterConfiguration.Status.ClusterProfileResources {
 		r := clusterConfiguration.Status.ClusterProfileResources[i]
-		a.addDeployedCharts(configv1alpha1.ClusterProfileKind, r.ClusterProfileName, r.Features, results)
+		a.addDeployedCharts(configv1beta1.ClusterProfileKind, r.ClusterProfileName, r.Features, results)
 	}
 	for i := range clusterConfiguration.Status.ProfileResources {
 		r := clusterConfiguration.Status.ProfileResources[i]
-		a.addDeployedCharts(configv1alpha1.ProfileKind, r.ProfileName, r.Features, results)
+		a.addDeployedCharts(configv1beta1.ProfileKind, r.ProfileName, r.Features, results)
 	}
 
 	return results
 }
 
 // GetResources returns list of resources deployed in a given cluster
-func (a *k8sAccess) GetResources(clusterConfiguration *configv1alpha1.ClusterConfiguration,
-	logger logr.Logger) map[configv1alpha1.Resource][]string {
+func (a *k8sAccess) GetResources(clusterConfiguration *configv1beta1.ClusterConfiguration,
+	logger logr.Logger) map[configv1beta1.Resource][]string {
 
 	logger = logger.WithValues("namespace", clusterConfiguration.Namespace,
 		"clusterConfiguration", clusterConfiguration.Name)
 
-	results := make(map[configv1alpha1.Resource][]string)
+	results := make(map[configv1beta1.Resource][]string)
 
 	logger.V(logs.LogDebug).Info("Get resources deployed in the cluster")
 	for i := range clusterConfiguration.Status.ClusterProfileResources {
 		r := clusterConfiguration.Status.ClusterProfileResources[i]
-		a.addDeployedResources(configv1alpha1.ClusterProfileKind, r.ClusterProfileName, r.Features, results)
+		a.addDeployedResources(configv1beta1.ClusterProfileKind, r.ClusterProfileName, r.Features, results)
 	}
 	for i := range clusterConfiguration.Status.ProfileResources {
 		r := clusterConfiguration.Status.ProfileResources[i]
-		a.addDeployedResources(configv1alpha1.ProfileKind, r.ProfileName, r.Features, results)
+		a.addDeployedResources(configv1beta1.ProfileKind, r.ProfileName, r.Features, results)
 	}
 
 	return results
 }
 
 func (a *k8sAccess) addDeployedCharts(profileKind, profileName string,
-	features []configv1alpha1.Feature, results map[configv1alpha1.Chart][]string) {
+	features []configv1beta1.Feature, results map[configv1beta1.Chart][]string) {
 
 	for i := range features {
 		a.addDeployedChartsForFeature(
@@ -119,7 +119,7 @@ func (a *k8sAccess) addDeployedCharts(profileKind, profileName string,
 }
 
 func (a *k8sAccess) addDeployedChartsForFeature(clusterProfilesName string,
-	charts []configv1alpha1.Chart, results map[configv1alpha1.Chart][]string) {
+	charts []configv1beta1.Chart, results map[configv1beta1.Chart][]string) {
 
 	for i := range charts {
 		chart := &charts[i]
@@ -133,7 +133,7 @@ func (a *k8sAccess) addDeployedChartsForFeature(clusterProfilesName string,
 }
 
 func (a *k8sAccess) addDeployedResources(profilesKind, profileName string,
-	features []configv1alpha1.Feature, results map[configv1alpha1.Resource][]string) {
+	features []configv1beta1.Feature, results map[configv1beta1.Resource][]string) {
 
 	for i := range features {
 		a.addDeployedResourcesForFeature(
@@ -143,7 +143,7 @@ func (a *k8sAccess) addDeployedResources(profilesKind, profileName string,
 }
 
 func (a *k8sAccess) addDeployedResourcesForFeature(profileName string,
-	resources []configv1alpha1.Resource, results map[configv1alpha1.Resource][]string) {
+	resources []configv1beta1.Resource, results map[configv1beta1.Resource][]string) {
 
 	for i := range resources {
 		resource := &resources[i]

--- a/internal/utils/clusterconfigurations_test.go
+++ b/internal/utils/clusterconfigurations_test.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	configv1alpha1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	"github.com/projectsveltos/sveltosctl/internal/utils"
 )
 
@@ -40,7 +40,7 @@ var _ = Describe("ClusterConfiguration", func() {
 		initObjects := []client.Object{}
 
 		for i := 0; i < 10; i++ {
-			clusterConfiguration := &configv1alpha1.ClusterConfiguration{
+			clusterConfiguration := &configv1beta1.ClusterConfiguration{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      randomString(),
 					Namespace: randomString(),
@@ -49,7 +49,7 @@ var _ = Describe("ClusterConfiguration", func() {
 			initObjects = append(initObjects, clusterConfiguration)
 		}
 
-		clusterConfiguration := &configv1alpha1.ClusterConfiguration{
+		clusterConfiguration := &configv1beta1.ClusterConfiguration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      randomString(),
 				Namespace: randomString(),
@@ -74,7 +74,7 @@ var _ = Describe("ClusterConfiguration", func() {
 	})
 
 	It("GetClusterConfiguration returns ClusterConfiguration for a given cluster ", func() {
-		clusterConfiguration := &configv1alpha1.ClusterConfiguration{
+		clusterConfiguration := &configv1beta1.ClusterConfiguration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      randomString(),
 				Namespace: randomString(),
@@ -102,7 +102,7 @@ var _ = Describe("ClusterConfiguration", func() {
 	})
 
 	It("GetHelmReleases returns deployed helm releases", func() {
-		chart1 := &configv1alpha1.Chart{
+		chart1 := &configv1beta1.Chart{
 			RepoURL:         randomString(),
 			ReleaseName:     randomString(),
 			Namespace:       randomString(),
@@ -110,7 +110,7 @@ var _ = Describe("ClusterConfiguration", func() {
 			LastAppliedTime: &metav1.Time{Time: time.Now()},
 		}
 
-		chart2 := &configv1alpha1.Chart{
+		chart2 := &configv1beta1.Chart{
 			RepoURL:         randomString(),
 			ReleaseName:     randomString(),
 			Namespace:       randomString(),
@@ -119,7 +119,7 @@ var _ = Describe("ClusterConfiguration", func() {
 		}
 
 		clusterConfiguration := createClusterConfiguration(nil, nil,
-			[]configv1alpha1.Chart{*chart1}, []configv1alpha1.Chart{*chart1, *chart2})
+			[]configv1beta1.Chart{*chart1}, []configv1beta1.Chart{*chart1, *chart2})
 		initObjects := []client.Object{clusterConfiguration}
 
 		scheme := runtime.NewScheme()
@@ -136,7 +136,7 @@ var _ = Describe("ClusterConfiguration", func() {
 	})
 
 	It("GetResources returns deployed resources", func() {
-		resource1 := &configv1alpha1.Resource{
+		resource1 := &configv1beta1.Resource{
 			Name:            randomString(),
 			Namespace:       randomString(),
 			Group:           randomString(),
@@ -144,7 +144,7 @@ var _ = Describe("ClusterConfiguration", func() {
 			LastAppliedTime: &metav1.Time{Time: time.Now()},
 		}
 
-		resource2 := &configv1alpha1.Resource{
+		resource2 := &configv1beta1.Resource{
 			Name:            randomString(),
 			Namespace:       randomString(),
 			Group:           randomString(),
@@ -153,7 +153,7 @@ var _ = Describe("ClusterConfiguration", func() {
 		}
 
 		clusterConfiguration := createClusterConfiguration(
-			[]configv1alpha1.Resource{*resource1}, []configv1alpha1.Resource{*resource1, *resource2},
+			[]configv1beta1.Resource{*resource1}, []configv1beta1.Resource{*resource1, *resource2},
 			nil, nil)
 		initObjects := []client.Object{clusterConfiguration}
 
@@ -171,38 +171,38 @@ var _ = Describe("ClusterConfiguration", func() {
 	})
 })
 
-func createClusterConfiguration(clusterProfile1Resources, clusterProfile2Resources []configv1alpha1.Resource,
-	clusterProfile1Charts, clusterProfile2Charts []configv1alpha1.Chart) *configv1alpha1.ClusterConfiguration {
+func createClusterConfiguration(clusterProfile1Resources, clusterProfile2Resources []configv1beta1.Resource,
+	clusterProfile1Charts, clusterProfile2Charts []configv1beta1.Chart) *configv1beta1.ClusterConfiguration {
 
-	cfr1 := &configv1alpha1.ClusterProfileResource{
+	cfr1 := &configv1beta1.ClusterProfileResource{
 		ClusterProfileName: randomString(),
-		Features: []configv1alpha1.Feature{
+		Features: []configv1beta1.Feature{
 			{
-				FeatureID: configv1alpha1.FeatureHelm,
+				FeatureID: configv1beta1.FeatureHelm,
 				Resources: clusterProfile1Resources,
 				Charts:    clusterProfile1Charts,
 			},
 		},
 	}
 
-	cfr2 := &configv1alpha1.ClusterProfileResource{
+	cfr2 := &configv1beta1.ClusterProfileResource{
 		ClusterProfileName: randomString(),
-		Features: []configv1alpha1.Feature{
+		Features: []configv1beta1.Feature{
 			{
-				FeatureID: configv1alpha1.FeatureHelm,
+				FeatureID: configv1beta1.FeatureHelm,
 				Resources: clusterProfile2Resources,
 				Charts:    clusterProfile2Charts,
 			},
 		},
 	}
 
-	return &configv1alpha1.ClusterConfiguration{
+	return &configv1beta1.ClusterConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      randomString(),
 			Namespace: randomString(),
 		},
-		Status: configv1alpha1.ClusterConfigurationStatus{
-			ClusterProfileResources: []configv1alpha1.ClusterProfileResource{
+		Status: configv1beta1.ClusterConfigurationStatus{
+			ClusterProfileResources: []configv1beta1.ClusterProfileResource{
 				*cfr1,
 				*cfr2,
 			},

--- a/internal/utils/clusterprofiles.go
+++ b/internal/utils/clusterprofiles.go
@@ -21,16 +21,16 @@ import (
 
 	"github.com/go-logr/logr"
 
-	configv1alpha1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
 )
 
 // ListClusterProfiles returns all current ClusterProfiles
 func (a *k8sAccess) ListClusterProfiles(ctx context.Context,
-	logger logr.Logger) (*configv1alpha1.ClusterProfileList, error) {
+	logger logr.Logger) (*configv1beta1.ClusterProfileList, error) {
 
 	logger.V(logs.LogDebug).Info("Get all ClusterProfiles")
-	clusterProfiles := &configv1alpha1.ClusterProfileList{}
+	clusterProfiles := &configv1beta1.ClusterProfileList{}
 	err := a.client.List(ctx, clusterProfiles)
 	return clusterProfiles, err
 }

--- a/internal/utils/clusterprofiles_test.go
+++ b/internal/utils/clusterprofiles_test.go
@@ -28,7 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	configv1alpha1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	"github.com/projectsveltos/sveltosctl/internal/utils"
 )
@@ -38,17 +38,17 @@ var _ = Describe("ClusterProfile", func() {
 		initObjects := []client.Object{}
 
 		for i := 0; i < 10; i++ {
-			clusterProfile := &configv1alpha1.ClusterProfile{
+			clusterProfile := &configv1beta1.ClusterProfile{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: randomString(),
 				},
-				Spec: configv1alpha1.Spec{
+				Spec: configv1beta1.Spec{
 					ClusterSelector: libsveltosv1beta1.Selector{
 						LabelSelector: metav1.LabelSelector{
 							MatchLabels: map[string]string{"zone": "west"},
 						},
 					},
-					SyncMode: configv1alpha1.SyncModeContinuous,
+					SyncMode: configv1beta1.SyncModeContinuous,
 				},
 			}
 			initObjects = append(initObjects, clusterProfile)

--- a/internal/utils/clusterreports.go
+++ b/internal/utils/clusterreports.go
@@ -23,26 +23,26 @@ import (
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	configv1alpha1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
 )
 
 // ListClusterReports returns all current ClusterReports in a namespace (if specified)
 func (a *k8sAccess) ListClusterReports(ctx context.Context, namespace string,
-	logger logr.Logger) (*configv1alpha1.ClusterReportList, error) {
+	logger logr.Logger) (*configv1beta1.ClusterReportList, error) {
 
 	listOptions := []client.ListOption{
 		client.InNamespace(namespace),
 	}
 
 	logger.V(logs.LogDebug).Info("Get all ClusterReports")
-	clusterReports := &configv1alpha1.ClusterReportList{}
+	clusterReports := &configv1beta1.ClusterReportList{}
 	err := a.client.List(ctx, clusterReports, listOptions...)
 	return clusterReports, err
 }
 
 // SortClusterReports sorts ClusterReports by Cluster Namespace/Name
-func (a *k8sAccess) SortClusterReports(clusterReports []configv1alpha1.ClusterReport) []configv1alpha1.ClusterReport {
+func (a *k8sAccess) SortClusterReports(clusterReports []configv1beta1.ClusterReport) []configv1beta1.ClusterReport {
 	sort.Slice(clusterReports, func(i, j int) bool {
 		if clusterReports[i].Spec.ClusterNamespace == clusterReports[j].Spec.ClusterNamespace {
 			return clusterReports[i].Spec.ClusterName < clusterReports[j].Spec.ClusterName

--- a/internal/utils/clusterreports_test.go
+++ b/internal/utils/clusterreports_test.go
@@ -28,7 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	configv1alpha1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	"github.com/projectsveltos/sveltosctl/internal/utils"
 )
 
@@ -38,7 +38,7 @@ var _ = Describe("ClusterReport", func() {
 		initObjects := []client.Object{}
 
 		for i := 0; i < 5; i++ {
-			clusterReport := &configv1alpha1.ClusterReport{
+			clusterReport := &configv1beta1.ClusterReport{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      randomString(),
 					Namespace: randomString(),
@@ -47,7 +47,7 @@ var _ = Describe("ClusterReport", func() {
 			initObjects = append(initObjects, clusterReport)
 		}
 
-		clusterReport := &configv1alpha1.ClusterReport{
+		clusterReport := &configv1beta1.ClusterReport{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      randomString(),
 				Namespace: randomString(),
@@ -72,29 +72,29 @@ var _ = Describe("ClusterReport", func() {
 	})
 
 	It("SortClusterReports sorts clusterReports by Cluster Namespace/Name", func() {
-		clusterReports := []configv1alpha1.ClusterReport{}
+		clusterReports := []configv1beta1.ClusterReport{}
 
 		firstNamespace := "namespace-a"
 		secondNamespace := "namespace-b"
 
-		clusterReport := &configv1alpha1.ClusterReport{
+		clusterReport := &configv1beta1.ClusterReport{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      randomString(),
 				Namespace: randomString(),
 			},
-			Spec: configv1alpha1.ClusterReportSpec{
+			Spec: configv1beta1.ClusterReportSpec{
 				ClusterName:      randomString(),
 				ClusterNamespace: secondNamespace,
 			},
 		}
 		clusterReports = append(clusterReports, *clusterReport)
 
-		clusterReport = &configv1alpha1.ClusterReport{
+		clusterReport = &configv1beta1.ClusterReport{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      randomString(),
 				Namespace: randomString(),
 			},
-			Spec: configv1alpha1.ClusterReportSpec{
+			Spec: configv1beta1.ClusterReportSpec{
 				ClusterName:      randomString(),
 				ClusterNamespace: firstNamespace,
 			},

--- a/internal/utils/profiles.go
+++ b/internal/utils/profiles.go
@@ -21,16 +21,16 @@ import (
 
 	"github.com/go-logr/logr"
 
-	configv1alpha1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
 )
 
 // ListClusterProfiles returns all current Profiles
 func (a *k8sAccess) ListProfiles(ctx context.Context,
-	logger logr.Logger) (*configv1alpha1.ProfileList, error) {
+	logger logr.Logger) (*configv1beta1.ProfileList, error) {
 
 	logger.V(logs.LogDebug).Info("Get all Profiles")
-	profiles := &configv1alpha1.ProfileList{}
+	profiles := &configv1beta1.ProfileList{}
 	err := a.client.List(ctx, profiles)
 	return profiles, err
 }

--- a/internal/utils/profiles_test.go
+++ b/internal/utils/profiles_test.go
@@ -28,7 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	configv1alpha1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	"github.com/projectsveltos/sveltosctl/internal/utils"
 )
@@ -38,17 +38,17 @@ var _ = Describe("Profile", func() {
 		initObjects := []client.Object{}
 
 		for i := 0; i < 15; i++ {
-			profile := &configv1alpha1.Profile{
+			profile := &configv1beta1.Profile{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: randomString(),
 				},
-				Spec: configv1alpha1.Spec{
+				Spec: configv1beta1.Spec{
 					ClusterSelector: libsveltosv1beta1.Selector{
 						LabelSelector: metav1.LabelSelector{
 							MatchLabels: map[string]string{"zone": "west"},
 						},
 					},
-					SyncMode: configv1alpha1.SyncModeContinuous,
+					SyncMode: configv1beta1.SyncModeContinuous,
 				},
 			}
 			initObjects = append(initObjects, profile)


### PR DESCRIPTION
Use `--raw-diff` options to display how helm charts are changing

```
sveltosctl show dryrun            
+--------------+--------------------------+-----------+-----------------------------+---------------+--------------------------------+----------------------------------------+
|   CLUSTER    |      RESOURCE TYPE       | NAMESPACE |            NAME             |    ACTION     |            MESSAGE             |                PROFILE                 |
+--------------+--------------------------+-----------+-----------------------------+---------------+--------------------------------+----------------------------------------+
| civo/cluster | helm release             | kyverno   | kyverno-latest              | Update Values | use --raw-diff to see full     | ClusterProfile/deploy-kyverno          |
|              |                          |           |                             |               | diff for helm values           |                                        |
| civo/cluster | kyverno.io:ClusterPolicy |           | disallow-latest-tag         | Update        | use --raw-diff to see full     | ClusterProfile/deploy-kyverno-policies |
|              |                          |           |                             |               | diff                           |                                        |
| civo/cluster | kyverno.io:ClusterPolicy |           | restrict-external-ips       | Create        |                                | ClusterProfile/deploy-kyverno-policies |
| civo/cluster | kyverno.io:ClusterPolicy |           | disallow-empty-ingress-host | Delete        |                                | ClusterProfile/deploy-kyverno-policies |
| gke/cluster  | helm release             | kyverno   | kyverno-latest              | Update Values | use --raw-diff to see full     | ClusterProfile/deploy-kyverno          |
|              |                          |           |                             |               | diff for helm values           |                                        |
| gke/cluster  | kyverno.io:ClusterPolicy |           | disallow-latest-tag         | Update        | use --raw-diff to see full     | ClusterProfile/deploy-kyverno-policies |
|              |                          |           |                             |               | diff                           |                                        |
| gke/cluster  | kyverno.io:ClusterPolicy |           | restrict-external-ips       | Create        |                                | ClusterProfile/deploy-kyverno-policies |
| gke/cluster  | kyverno.io:ClusterPolicy |           | disallow-empty-ingress-host | Delete        |                                | ClusterProfile/deploy-kyverno-policies |
+--------------+--------------------------+-----------+-----------------------------+---------------+--------------------------------+----------------------------------------+
```


with `--raw-diff`` option


```
sveltosctl show dryrun  --raw-diff
Profile: ClusterProfile:deploy-kyverno Cluster: civo/cluster
--- deployed values
+++ proposed values
@@ -1,4 +1,4 @@
 admissionController:
-    replicas: 1
+    replicas: 3
 backgroundController:
-    replicas: 1
+    replicas: 3

Profile: ClusterProfile:deploy-kyverno-policies Cluster: civo/cluster
--- deployed: ClusterPolicy disallow-latest-tag
+++ proposed: ClusterPolicy disallow-latest-tag
@@ -49,10 +49,10 @@
               name: validate-image-tag
               skipBackgroundRequests: true
               validate:
-                message: Using a mutable image tag e.g. 'latest' is not allowed in this cluster.
+                message: Using a mutable image tag e.g. 'latest' is not allowed.
                 pattern:
                     spec:
                         containers:
                             - image: '!*:latest'
-        validationFailureAction: enforce
+        validationFailureAction: audit
     status: ""

Profile: ClusterProfile:deploy-kyverno Cluster: gke/cluster
--- deployed values
+++ proposed values
@@ -1,4 +1,4 @@
 admissionController:
-    replicas: 1
+    replicas: 3
 backgroundController:
-    replicas: 1
+    replicas: 3

Profile: ClusterProfile:deploy-kyverno-policies Cluster: gke/cluster
--- deployed: ClusterPolicy disallow-latest-tag
+++ proposed: ClusterPolicy disallow-latest-tag
@@ -49,10 +49,10 @@
               name: validate-image-tag
               skipBackgroundRequests: true
               validate:
-                message: Using a mutable image tag e.g. 'latest' is not allowed in this cluster.
+                message: Using a mutable image tag e.g. 'latest' is not allowed.
                 pattern:
                     spec:
                         containers:
                             - image: '!*:latest'
-        validationFailureAction: enforce
+        validationFailureAction: audit
     status: ""
```
