### PR TITLE
help and version always work

### DIFF
--- a/internal/commands/version.go
+++ b/internal/commands/version.go
@@ -39,10 +39,11 @@ func Version(args []string, logger logr.Logger) error {
 
 Options:
   -h --help             Show this screen.
- 
+
 Description:
   Display the version of sveltosctl.
 `
+
 	parser := &docopt.Parser{
 		HelpHandler:   docopt.PrintHelpAndExit,
 		OptionsFirst:  true,


### PR DESCRIPTION
Previously, sveltosctl would remain silent if it couldn't connect to the cluster.

This pull request changes that behavior. Now, the `version` and `--help` commands will always display output, regardless of the cluster's reachability.