### PR TITLE
Extend log-level commands to support managed clusters

### DIFF
--- a/internal/commands/loglevel/export_test.go
+++ b/internal/commands/loglevel/export_test.go
@@ -17,7 +17,12 @@ limitations under the License.
 package loglevel
 
 var (
-	ShowLogSettings              = showLogSettings
-	UpdateDebuggingConfiguration = updateDebuggingConfiguration
-	UnsetDebuggingConfiguration  = unsetDebuggingConfiguration
+	ShowLogSettings                        = showLogSettings
+	UpdateDebuggingConfiguration           = updateDebuggingConfiguration
+	UnsetDebuggingConfiguration            = unsetDebuggingConfiguration
+	UpdateDebuggingConfigurationInManaged  = updateDebuggingConfigurationInManaged
+	CollectLogLevelConfigurationFromClient = collectLogLevelConfigurationFromClient
+	UpdateLogLevelConfigurationWithClient  = updateLogLevelConfigurationWithClient
+	ShowLogSettingsInManaged               = showLogSettingsInManaged
+	UnsetDebuggingConfigurationInManaged   = unsetDebuggingConfigurationInManaged
 )

--- a/internal/commands/loglevel/set.go
+++ b/internal/commands/loglevel/set.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"strings"
 
-	docopt "github.com/docopt/docopt-go"
+	"github.com/docopt/docopt-go"
 
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 )
@@ -34,9 +34,35 @@ func updateDebuggingConfiguration(ctx context.Context, logSeverity libsveltosv1b
 		return nil
 	}
 
-	found := false
-	spec := make([]libsveltosv1beta1.ComponentConfiguration, len(cc))
+	spec := buildUpdatedSpec(cc, component, logSeverity)
+	return updateLogLevelConfiguration(ctx, spec)
+}
 
+func updateDebuggingConfigurationInManaged(ctx context.Context, logSeverity libsveltosv1beta1.LogLevel,
+	component, namespace, clusterName string, clusterType libsveltosv1beta1.ClusterType) error {
+
+	managedClient, err := getManagedClusterClient(ctx, namespace, clusterName, clusterType)
+	if err != nil {
+		return err
+	}
+
+	cc, err := collectLogLevelConfigurationFromClient(ctx, managedClient)
+	if err != nil {
+		return err
+	}
+
+	spec := buildUpdatedSpec(cc, component, logSeverity)
+	return updateLogLevelConfigurationWithClient(ctx, managedClient, spec)
+}
+
+// buildUpdatedSpec returns the ComponentConfiguration slice that would result
+// from setting component to logSeverity, preserving existing entries for other
+// components.
+func buildUpdatedSpec(cc []*componentConfiguration, component string,
+	logSeverity libsveltosv1beta1.LogLevel) []libsveltosv1beta1.ComponentConfiguration {
+
+	spec := make([]libsveltosv1beta1.ComponentConfiguration, len(cc))
+	found := false
 	for i, c := range cc {
 		if string(c.component) == component {
 			spec[i] = libsveltosv1beta1.ComponentConfiguration{
@@ -44,7 +70,6 @@ func updateDebuggingConfiguration(ctx context.Context, logSeverity libsveltosv1b
 				LogLevel:  logSeverity,
 			}
 			found = true
-			break
 		} else {
 			spec[i] = libsveltosv1beta1.ComponentConfiguration{
 				Component: c.component,
@@ -62,22 +87,31 @@ func updateDebuggingConfiguration(ctx context.Context, logSeverity libsveltosv1b
 		)
 	}
 
-	return updateLogLevelConfiguration(ctx, spec)
+	return spec
 }
 
-// Set displays/changes log verbosity for a given component
+// Set displays/changes log verbosity for a given component.
+//
+// When --namespace and --clusterName are provided, the DebuggingConfiguration
+// is updated in the specified managed cluster. Otherwise, it is updated in the
+// management cluster.
 func Set(ctx context.Context, args []string) error {
 	doc := `Usage:
-  sveltosctl log-level set --component=<name> (--info|--debug|--verbose)
+  sveltosctl log-level set --component=<name> (--info|--debug|--verbose) [--namespace=<namespace>] [--clusterName=<cluster-name>] [--clusterType=<cluster-type>]
 Options:
-  -h --help             Show this screen.
-     --component=<name> Name of the component for which log severity is being set.
-     --info             Set log severity to info.
-     --debug            Set log severity to debug.
-     --verbose          Set log severity to verbose.
-	 
+  -h --help                        Show this screen.
+     --component=<name>            Name of the component for which log severity is being set.
+     --info                        Set log severity to info.
+     --debug                       Set log severity to debug.
+     --verbose                     Set log severity to verbose.
+     --namespace=<namespace>       (Optional) Namespace of the managed cluster.
+     --clusterName=<cluster-name>  (Optional) Name of the managed cluster.
+     --clusterType=<cluster-type>  (Optional) Type of managed cluster: Capi or Sveltos. Defaults to Capi.
+
 Description:
   The log-level set command set log severity for the specified component.
+  If --namespace and --clusterName are provided, log severity is set in the
+  specified managed cluster. Otherwise it is set in the management cluster.
 `
 	parsedArgs, err := docopt.ParseArgs(doc, nil, "1.0")
 	if err != nil {
@@ -95,18 +129,27 @@ Description:
 		component = passedComponent.(string)
 	}
 
+	namespace, clusterName, clusterType, err := parseManagedClusterArgs(parsedArgs)
+	if err != nil {
+		return err
+	}
+
 	info := parsedArgs["--info"].(bool)
 	debug := parsedArgs["--debug"].(bool)
 	verbose := parsedArgs["--verbose"].(bool)
 
 	var logSeverity libsveltosv1beta1.LogLevel
-	if info {
+	switch {
+	case info:
 		logSeverity = libsveltosv1beta1.LogLevelInfo
-	} else if debug {
+	case debug:
 		logSeverity = libsveltosv1beta1.LogLevelDebug
-	} else if verbose {
+	case verbose:
 		logSeverity = libsveltosv1beta1.LogLevelVerbose
 	}
 
+	if namespace != "" && clusterName != "" {
+		return updateDebuggingConfigurationInManaged(ctx, logSeverity, component, namespace, clusterName, clusterType)
+	}
 	return updateDebuggingConfiguration(ctx, logSeverity, component)
 }

--- a/internal/commands/loglevel/show.go
+++ b/internal/commands/loglevel/show.go
@@ -22,8 +22,10 @@ import (
 	"os"
 	"strings"
 
-	docopt "github.com/docopt/docopt-go"
+	"github.com/docopt/docopt-go"
 	"github.com/olekukonko/tablewriter"
+
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 )
 
 func showLogSettings(ctx context.Context) error {
@@ -32,17 +34,31 @@ func showLogSettings(ctx context.Context) error {
 		return err
 	}
 
-	table := tablewriter.NewWriter(os.Stdout)
-	table.Header([]string{"COMPONENT", "VERBOSITY"})
-	genRow := func(component, verbosity string) []string {
-		return []string{
-			component,
-			verbosity,
-		}
+	return renderLogSettings(componentConfiguration)
+}
+
+func showLogSettingsInManaged(ctx context.Context, namespace, clusterName string,
+	clusterType libsveltosv1beta1.ClusterType) error {
+
+	managedClient, err := getManagedClusterClient(ctx, namespace, clusterName, clusterType)
+	if err != nil {
+		return err
 	}
 
-	for _, c := range componentConfiguration {
-		if err := table.Append(genRow(string(c.component), string(c.logSeverity))); err != nil {
+	componentConfiguration, err := collectLogLevelConfigurationFromClient(ctx, managedClient)
+	if err != nil {
+		return err
+	}
+
+	return renderLogSettings(componentConfiguration)
+}
+
+func renderLogSettings(cc []*componentConfiguration) error {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.Header([]string{"COMPONENT", "VERBOSITY"})
+
+	for _, c := range cc {
+		if err := table.Append([]string{string(c.component), string(c.logSeverity)}); err != nil {
 			return err
 		}
 	}
@@ -50,15 +66,25 @@ func showLogSettings(ctx context.Context) error {
 	return table.Render()
 }
 
-// Show displays information about log verbosity (if set)
+// Show displays information about log verbosity (if set).
+//
+// When --namespace and --clusterName are provided, settings are read from the
+// specified managed cluster. Otherwise they are read from the management
+// cluster.
 func Show(ctx context.Context, args []string) error {
 	doc := `Usage:
-  sveltosctl log-level show
+  sveltosctl log-level show [--namespace=<namespace>] [--clusterName=<cluster-name>] [--clusterType=<cluster-type>]
 Options:
-  -h --help             Show this screen.
-     
+  -h --help                        Show this screen.
+     --namespace=<namespace>       (Optional) Namespace of the managed cluster.
+     --clusterName=<cluster-name>  (Optional) Name of the managed cluster.
+     --clusterType=<cluster-type>  (Optional) Type of managed cluster: Capi or Sveltos. Defaults to Capi.
+
 Description:
   The log-level show command shows information about current log verbosity.
+  If --namespace and --clusterName are provided, settings are read from the
+  specified managed cluster. Otherwise they are read from the management
+  cluster.
 `
 	parsedArgs, err := docopt.ParseArgs(doc, nil, "1.0")
 	if err != nil {
@@ -71,5 +97,13 @@ Description:
 		return nil
 	}
 
+	namespace, clusterName, clusterType, err := parseManagedClusterArgs(parsedArgs)
+	if err != nil {
+		return err
+	}
+
+	if namespace != "" && clusterName != "" {
+		return showLogSettingsInManaged(ctx, namespace, clusterName, clusterType)
+	}
 	return showLogSettings(ctx)
 }

--- a/internal/commands/loglevel/unset.go
+++ b/internal/commands/loglevel/unset.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"strings"
 
-	docopt "github.com/docopt/docopt-go"
+	"github.com/docopt/docopt-go"
 
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 )
@@ -32,39 +32,72 @@ func unsetDebuggingConfiguration(ctx context.Context, component string) error {
 		return nil
 	}
 
-	found := false
-	spec := make([]libsveltosv1beta1.ComponentConfiguration, 0)
+	spec, found := removeComponent(cc, component)
+	if !found {
+		return nil
+	}
+	return updateLogLevelConfiguration(ctx, spec)
+}
 
+func unsetDebuggingConfigurationInManaged(ctx context.Context, component, namespace,
+	clusterName string, clusterType libsveltosv1beta1.ClusterType) error {
+
+	managedClient, err := getManagedClusterClient(ctx, namespace, clusterName, clusterType)
+	if err != nil {
+		return err
+	}
+
+	cc, err := collectLogLevelConfigurationFromClient(ctx, managedClient)
+	if err != nil {
+		return err
+	}
+
+	spec, found := removeComponent(cc, component)
+	if !found {
+		return nil
+	}
+	return updateLogLevelConfigurationWithClient(ctx, managedClient, spec)
+}
+
+// removeComponent returns the ComponentConfiguration slice with component
+// removed, along with a flag indicating whether it was present.
+func removeComponent(cc []*componentConfiguration,
+	component string) ([]libsveltosv1beta1.ComponentConfiguration, bool) {
+
+	spec := make([]libsveltosv1beta1.ComponentConfiguration, 0, len(cc))
+	found := false
 	for _, c := range cc {
 		if string(c.component) == component {
 			found = true
 			continue
-		} else {
-			spec = append(spec,
-				libsveltosv1beta1.ComponentConfiguration{
-					Component: c.component,
-					LogLevel:  c.logSeverity,
-				},
-			)
 		}
+		spec = append(spec, libsveltosv1beta1.ComponentConfiguration{
+			Component: c.component,
+			LogLevel:  c.logSeverity,
+		})
 	}
-
-	if found {
-		return updateLogLevelConfiguration(ctx, spec)
-	}
-	return nil
+	return spec, found
 }
 
-// Unset resets log verbosity for a given component
+// Unset resets log verbosity for a given component.
+//
+// When --namespace and --clusterName are provided, the DebuggingConfiguration
+// is updated in the specified managed cluster. Otherwise, it is updated in the
+// management cluster.
 func Unset(ctx context.Context, args []string) error {
 	doc := `Usage:
-  sveltosctl log-level unset --component=<name>
+  sveltosctl log-level unset --component=<name> [--namespace=<namespace>] [--clusterName=<cluster-name>] [--clusterType=<cluster-type>]
 Options:
-  -h --help             Show this screen.
-     --component=<name> Name of the component for which log severity is being set.
-	 
+  -h --help                        Show this screen.
+     --component=<name>            Name of the component for which log severity is being unset.
+     --namespace=<namespace>       (Optional) Namespace of the managed cluster.
+     --clusterName=<cluster-name>  (Optional) Name of the managed cluster.
+     --clusterType=<cluster-type>  (Optional) Type of managed cluster: Capi or Sveltos. Defaults to Capi.
+
 Description:
-  The log-level set command set log severity for the specified component.
+  The log-level unset command unsets log severity for the specified component.
+  If --namespace and --clusterName are provided, log severity is unset in the
+  specified managed cluster. Otherwise it is unset in the management cluster.
 `
 	parsedArgs, err := docopt.ParseArgs(doc, nil, "1.0")
 	if err != nil {
@@ -82,5 +115,13 @@ Description:
 		component = passedComponent.(string)
 	}
 
+	namespace, clusterName, clusterType, err := parseManagedClusterArgs(parsedArgs)
+	if err != nil {
+		return err
+	}
+
+	if namespace != "" && clusterName != "" {
+		return unsetDebuggingConfigurationInManaged(ctx, component, namespace, clusterName, clusterType)
+	}
 	return unsetDebuggingConfiguration(ctx, component)
 }

--- a/internal/commands/loglevel/utils.go
+++ b/internal/commands/loglevel/utils.go
@@ -18,14 +18,68 @@ package loglevel
 
 import (
 	"context"
+	"fmt"
 	"sort"
 
+	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
+	"github.com/projectsveltos/libsveltos/lib/clusterproxy"
 	"github.com/projectsveltos/sveltosctl/internal/utils"
 )
+
+const (
+	defaultDebuggingConfigurationName = "default"
+)
+
+// getManagedClusterClient returns a controller-runtime client for the managed
+// cluster identified by (namespace, clusterName, clusterType), using the
+// management cluster client to look up credentials via libsveltos clusterproxy.
+func getManagedClusterClient(ctx context.Context, namespace, clusterName string,
+	clusterType libsveltosv1beta1.ClusterType) (client.Client, error) {
+
+	managedClient, err := clusterproxy.GetKubernetesClient(ctx, utils.GetAccessInstance().GetClient(),
+		namespace, clusterName, "", "", clusterType, logr.Discard())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get client for managed cluster %s/%s: %w",
+			namespace, clusterName, err)
+	}
+	return managedClient, nil
+}
+
+// parseManagedClusterArgs extracts the optional --namespace, --clusterName and
+// --clusterType values from the parsed docopt args. clusterType defaults to
+// Capi; any value other than "Sveltos" (case-sensitive) falls back to Capi for
+// backward compatibility with existing invocations.
+func parseManagedClusterArgs(parsedArgs map[string]interface{}) (
+	namespace, clusterName string, clusterType libsveltosv1beta1.ClusterType, err error) {
+
+	if v := parsedArgs["--namespace"]; v != nil {
+		namespace = v.(string)
+	}
+	if v := parsedArgs["--clusterName"]; v != nil {
+		clusterName = v.(string)
+	}
+
+	clusterType = libsveltosv1beta1.ClusterTypeCapi
+	if v := parsedArgs["--clusterType"]; v != nil {
+		switch v.(string) {
+		case string(libsveltosv1beta1.ClusterTypeSveltos):
+			clusterType = libsveltosv1beta1.ClusterTypeSveltos
+		case string(libsveltosv1beta1.ClusterTypeCapi):
+			clusterType = libsveltosv1beta1.ClusterTypeCapi
+		default:
+			return "", "", "", fmt.Errorf(
+				"invalid --clusterType %q: must be %q or %q",
+				v, libsveltosv1beta1.ClusterTypeCapi, libsveltosv1beta1.ClusterTypeSveltos)
+		}
+	}
+
+	return namespace, clusterName, clusterType, nil
+}
 
 type componentConfiguration struct {
 	component   libsveltosv1beta1.Component
@@ -92,4 +146,60 @@ func updateLogLevelConfiguration(
 	}
 
 	return instance.UpdateDebuggingConfiguration(ctx, dc)
+}
+
+// collectLogLevelConfigurationFromClient returns the current log-level
+// configuration read from the DebuggingConfiguration "default" instance
+// accessible through the provided client.
+func collectLogLevelConfigurationFromClient(ctx context.Context,
+	c client.Client) ([]*componentConfiguration, error) {
+
+	dc := &libsveltosv1beta1.DebuggingConfiguration{}
+	err := c.Get(ctx, client.ObjectKey{Name: defaultDebuggingConfigurationName}, dc)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return make([]*componentConfiguration, 0), nil
+		}
+		return nil, err
+	}
+
+	configurationSettings := make([]*componentConfiguration, len(dc.Spec.Configuration))
+	for i, c := range dc.Spec.Configuration {
+		configurationSettings[i] = &componentConfiguration{
+			component:   c.Component,
+			logSeverity: c.LogLevel,
+		}
+	}
+
+	sort.Sort(byComponent(configurationSettings))
+	return configurationSettings, nil
+}
+
+// updateLogLevelConfigurationWithClient writes spec to the DebuggingConfiguration
+// "default" instance accessible through the provided client, creating it if it
+// does not exist.
+func updateLogLevelConfigurationWithClient(ctx context.Context, c client.Client,
+	spec []libsveltosv1beta1.ComponentConfiguration) error {
+
+	dc := &libsveltosv1beta1.DebuggingConfiguration{}
+	err := c.Get(ctx, client.ObjectKey{Name: defaultDebuggingConfigurationName}, dc)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+		dc = &libsveltosv1beta1.DebuggingConfiguration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: defaultDebuggingConfigurationName,
+			},
+			Spec: libsveltosv1beta1.DebuggingConfigurationSpec{
+				Configuration: spec,
+			},
+		}
+		return c.Create(ctx, dc)
+	}
+
+	dc.Spec = libsveltosv1beta1.DebuggingConfigurationSpec{
+		Configuration: spec,
+	}
+	return c.Update(ctx, dc)
 }


### PR DESCRIPTION
I first built the project to get the binary with `make build`.

Testing logs:

```
sveltosctl on  feature/extend-log-command-managed-clusters-v2 via 🐹 v1.26.2
❯ ./bin/sveltosctl log-level show
┌───────────────────────┬──────────────┐
│       COMPONENT       │  VERBOSITY   │
├───────────────────────┼──────────────┤
│ AccessManager         │ LogLevelInfo │
│ AddonManager          │ LogLevelInfo │
│ Classifier            │ LogLevelInfo │
│ ConversionWebhook     │ LogLevelInfo │                                                │ DriftDetectionManager │ LogLevelInfo │
│ EventManager          │ LogLevelInfo │
│ HealthCheckManager    │ LogLevelInfo │
│ ShardController       │ LogLevelInfo │                                                │ SveltosAgent          │ LogLevelInfo │
│ SveltosClusterManager │ LogLevelInfo │                                                │ Techsupport           │ LogLevelInfo │
│ UIBackend             │ LogLevelInfo │
└───────────────────────┴──────────────┘
sveltosctl on  feature/extend-log-command-managed-clusters-v2 via 🐹 v1.26.2           ❯ ./bin/sveltosctl log-level show --help
                                                Usage:
  sveltosctl log-level show [--namespace=<namespace>] [--clusterName=<cluster-name>] [--clusterType=<cluster-type>]
Options:
  -h --help                        Show this screen.                                         --namespace=<namespace>       (Optional) Namespace of the managed cluster.              --clusterName=<cluster-name>  (Optional) Name of the managed cluster.                   --clusterType=<cluster-type>  (Optional) Type of managed cluster: Capi or Sveltos. Defaults to Capi.
                                                                       Description:                                                                              The log-level show command shows information about current log verbosity.               If --namespace and --clusterName are provided, settings are read from the
  specified managed cluster. Otherwise they are read from the management
  cluster.
sveltosctl on  feature/extend-log-command-managed-clusters-v2 via 🐹 v1.26.2           ❯
```