### PR TITLE
(bug) Set SveltosCluster.Spec.KubeconfigKeyName

### DIFF
--- a/internal/commands/onboard/cluster.go
+++ b/internal/commands/onboard/cluster.go
@@ -88,6 +88,7 @@ func patchSveltosCluster(ctx context.Context, clusterNamespace, clusterName stri
 			currentSveltosCluster.Namespace = clusterNamespace
 			currentSveltosCluster.Name = clusterName
 			currentSveltosCluster.Labels = labels
+			currentSveltosCluster.Spec.KubeconfigKeyName = kubeconfig
 			if renew {
 				currentSveltosCluster.Spec.TokenRequestRenewalOption = &libsveltosv1beta1.TokenRequestRenewalOption{
 					RenewTokenRequestInterval: metav1.Duration{Duration: 24 * time.Hour},
@@ -101,6 +102,7 @@ func patchSveltosCluster(ctx context.Context, clusterNamespace, clusterName stri
 
 	logger.V(logs.LogDebug).Info("Updating SveltosCluster")
 	currentSveltosCluster.Labels = labels
+	currentSveltosCluster.Spec.KubeconfigKeyName = kubeconfig
 	return instance.UpdateResource(ctx, currentSveltosCluster)
 }
 


### PR DESCRIPTION
When a cluster is registered with Sveltos, a Secret containing the cluster's kubeconfig is created.
The kubeconfig is stored under the key __kubeconfig__ within this Secret.

If Sveltos renews the token, the key is updated to __re-kubeconfig__, and the `SveltosCluster.Spec.KubeconfigKeyName` is updated to reflect this change.

If you run the `sveltosctl register cluster` command again, the Secret's data is reset, and the cluster's kubeconfig is once again stored under the __kubeconfig__ key.

Previously, this would cause issues because the `SveltosCluster.Spec.KubeconfigKeyName` was not updated back to __kubeconfig__.
This PR resolves that problem by ensuring that `SveltosCluster.Spec.KubeconfigKeyName` is correctly updated to match the key in the Secret, preventing Sveltos components from failing to find the cluster's kubeconfig.

Fixes [1323](https://github.com/projectsveltos/addon-controller/issues/1323)