### PR TITLE
(feat) Register cluster: add option to pass shard key

### DIFF
--- a/internal/commands/onboard/cluster.go
+++ b/internal/commands/onboard/cluster.go
@@ -46,7 +46,7 @@ const (
 	kubeconfig                         = "kubeconfig"
 )
 
-func onboardSveltosCluster(ctx context.Context, clusterNamespace, clusterName string, kubeconfigData []byte,
+func onboardSveltosCluster(ctx context.Context, clusterNamespace, clusterName, shard string, kubeconfigData []byte,
 	labels map[string]string, renew bool, logger logr.Logger) error {
 
 	instance := utils.GetAccessInstance()
@@ -64,7 +64,7 @@ func onboardSveltosCluster(ctx context.Context, clusterNamespace, clusterName st
 		return err
 	}
 
-	err = patchSveltosCluster(ctx, clusterNamespace, clusterName, labels, renew, logger)
+	err = patchSveltosCluster(ctx, clusterNamespace, clusterName, shard, labels, renew, logger)
 	if err != nil {
 		return err
 	}
@@ -74,7 +74,7 @@ func onboardSveltosCluster(ctx context.Context, clusterNamespace, clusterName st
 	return nil
 }
 
-func patchSveltosCluster(ctx context.Context, clusterNamespace, clusterName string,
+func patchSveltosCluster(ctx context.Context, clusterNamespace, clusterName, shard string,
 	labels map[string]string, renew bool, logger logr.Logger) error {
 
 	instance := utils.GetAccessInstance()
@@ -95,6 +95,11 @@ func patchSveltosCluster(ctx context.Context, clusterNamespace, clusterName stri
 					TokenDuration:             metav1.Duration{Duration: 5 * time.Hour},
 				}
 			}
+			if shard != "" {
+				currentSveltosCluster.Annotations = map[string]string{
+					"sharding.projectsveltos.io/key": shard,
+				}
+			}
 
 			return instance.CreateResource(ctx, currentSveltosCluster)
 		}
@@ -104,6 +109,13 @@ func patchSveltosCluster(ctx context.Context, clusterNamespace, clusterName stri
 	logger.V(logs.LogDebug).Info("Updating SveltosCluster")
 	currentSveltosCluster.Labels = labels
 	currentSveltosCluster.Spec.KubeconfigKeyName = kubeconfig
+	if shard != "" {
+		currentSveltosCluster.Annotations = map[string]string{
+			"sharding.projectsveltos.io/key": shard,
+		}
+	} else if currentSveltosCluster.Annotations != nil {
+		delete(currentSveltosCluster.Annotations, "sharding.projectsveltos.io/key")
+	}
 	return instance.UpdateResource(ctx, currentSveltosCluster)
 }
 
@@ -135,7 +147,7 @@ func patchSecret(ctx context.Context, clusterNamespace, secretName string, kubec
 func RegisterCluster(ctx context.Context, args []string, logger logr.Logger) error { //nolint: funlen // command description
 	doc := `Usage:
   sveltosctl register cluster [options] --namespace=<name> --cluster=<name> [--kubeconfig=<file>] [--fleet-cluster-context=<value>] [--pullmode]
-                                [--labels=<value>] [--service-account-token] [--verbose]
+                                [--labels=<value>] [--shard=<key>] [--service-account-token] [--verbose]
 
      --namespace=<name>                  Specifies the namespace where Sveltos will create a resource (SveltosCluster) to represent
                                          the registered cluster.
@@ -164,7 +176,10 @@ func RegisterCluster(ctx context.Context, args []string, logger logr.Logger) err
                                          being created. The format for labels is <key1=value1,key2=value2>, where each key-value
                                          pair is separated by a comma (,) and the key and value are separated by an equal sign (=).
                                          You can define multiple labels by adding more key-value pairs separated by commas.
-    --service-account-token              (Optional) Use a non-expiring ServiceAccount token for management cluster registration.
+     --shard=<shard key>                 Optional. Assigns the cluster to a specific controller shard. This automatically adds the annotation
+                                         sharding.projectsveltos.io/key: <value> to the SveltosCluster resource, ensuring the correct shard
+                                         processes it.
+     --service-account-token             (Optional) Use a non-expiring ServiceAccount token for management cluster registration.
                                          When enabled, Sveltos will automatically create the necessary ServiceAccount infrastructure
                                          (ServiceAccount, ClusterRole, and ClusterRoleBinding) in the managed cluster and
                                          generate a long-lived token by also creating a Secret of type kubernetes.io/service-account-token.
@@ -216,6 +231,11 @@ Description:
 		}
 	}
 
+	shard := ""
+	if passedShard := parsedArgs["--shard"]; passedShard != nil {
+		shard = passedShard.(string)
+	}
+
 	_ = flag.Lookup("v").Value.Set(fmt.Sprint(logs.LogInfo))
 	pullMode := parsedArgs["--pullmode"].(bool)
 
@@ -240,7 +260,7 @@ Description:
 	}
 
 	if pullMode {
-		return onboardSveltosClusterInPullMode(ctx, namespace, cluster, labels, logger)
+		return onboardSveltosClusterInPullMode(ctx, namespace, cluster, shard, labels, logger)
 	}
 
 	if kubeconfig == "" && fleetClusterContext == "" {
@@ -252,7 +272,7 @@ Description:
 		return err
 	}
 
-	return onboardSveltosCluster(ctx, namespace, cluster, data, labels, renew, logger)
+	return onboardSveltosCluster(ctx, namespace, cluster, shard, data, labels, renew, logger)
 }
 
 func getKubeconfigData(ctx context.Context, kubeconfigFile, fleetClusterContext string,

--- a/internal/commands/onboard/cluster_test.go
+++ b/internal/commands/onboard/cluster_test.go
@@ -55,7 +55,8 @@ var _ = Describe("OnboardCluster", func() {
 			randomString(): randomString(),
 		}
 
-		Expect(onboard.OnboardSveltosCluster(context.TODO(), clusterNamespace, clusterName, kubeconfigData,
+		shardKey := randomString()
+		Expect(onboard.OnboardSveltosCluster(context.TODO(), clusterNamespace, clusterName, shardKey, kubeconfigData,
 			labels, false, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(Succeed())
 
 		instance := utils.GetAccessInstance()
@@ -65,6 +66,8 @@ var _ = Describe("OnboardCluster", func() {
 			types.NamespacedName{Namespace: clusterNamespace, Name: clusterName}, sveltosCluster)
 		Expect(err).To(BeNil())
 		Expect(reflect.DeepEqual(sveltosCluster.Labels, labels)).To(BeTrue())
+		Expect(sveltosCluster.Annotations).ToNot(BeNil())
+		Expect(sveltosCluster.Annotations["sharding.projectsveltos.io/key"]).To(Equal(shardKey))
 
 		secret := &corev1.Secret{}
 		secretName := clusterName + onboard.SveltosKubeconfigSecretNamePostfix
@@ -80,7 +83,12 @@ var _ = Describe("OnboardCluster", func() {
 			randomString(): randomString(),
 		}
 
-		Expect(onboard.OnboardSveltosCluster(context.TODO(), clusterNamespace, clusterName, kubeconfigData,
+		Expect(onboard.OnboardSveltosCluster(context.TODO(), clusterNamespace, clusterName, "", kubeconfigData,
 			labels, false, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(Succeed())
+		err = instance.GetResource(context.TODO(),
+			types.NamespacedName{Namespace: clusterNamespace, Name: clusterName}, sveltosCluster)
+		Expect(err).To(BeNil())
+		Expect(reflect.DeepEqual(sveltosCluster.Labels, labels)).To(BeTrue())
+		Expect(sveltosCluster.Annotations).To(BeNil())
 	})
 })

--- a/internal/commands/onboard/pullmode.go
+++ b/internal/commands/onboard/pullmode.go
@@ -45,7 +45,7 @@ import (
 	"github.com/projectsveltos/sveltosctl/internal/utils"
 )
 
-func onboardSveltosClusterInPullMode(ctx context.Context, clusterNamespace, clusterName string,
+func onboardSveltosClusterInPullMode(ctx context.Context, clusterNamespace, clusterName, shard string,
 	labels map[string]string, logger logr.Logger) error {
 
 	instance := utils.GetAccessInstance()
@@ -93,7 +93,7 @@ func onboardSveltosClusterInPullMode(ctx context.Context, clusterNamespace, clus
 		return err
 	}
 
-	err = createSveltosCluster(ctx, c, clusterNamespace, clusterName, labels)
+	err = createSveltosCluster(ctx, c, clusterNamespace, clusterName, shard, labels)
 	if err != nil {
 		logger.V(logs.LogDebug).Info(fmt.Sprintf("createSveltosCluster failed: %s", err))
 		return err
@@ -358,8 +358,9 @@ func createClusterRoleBinding(ctx context.Context, c client.Client, namespace, n
 	return err
 }
 
-func updateSveltosClusterLabels(ctx context.Context, c client.Client, sveltosCluster *libsveltosv1beta1.SveltosCluster,
-	labels map[string]string) error {
+func updateSveltosClusterLabelsAndAnnotations(ctx context.Context, c client.Client,
+	sveltosCluster *libsveltosv1beta1.SveltosCluster, labels map[string]string,
+	shard string) error {
 
 	lbls := sveltosCluster.Labels
 	if lbls == nil {
@@ -371,17 +372,26 @@ func updateSveltosClusterLabels(ctx context.Context, c client.Client, sveltosClu
 	}
 
 	sveltosCluster.Labels = lbls
+
+	if shard != "" {
+		sveltosCluster.Annotations = map[string]string{
+			"sharding.projectsveltos.io/key": shard,
+		}
+	} else if sveltosCluster.Annotations != nil {
+		delete(sveltosCluster.Annotations, "sharding.projectsveltos.io/key")
+	}
+
 	return c.Update(ctx, sveltosCluster)
 }
 
-func createSveltosCluster(ctx context.Context, c client.Client, namespace, name string,
+func createSveltosCluster(ctx context.Context, c client.Client, namespace, name, shard string,
 	labels map[string]string) error {
 
 	currentSveltosCluster := &libsveltosv1beta1.SveltosCluster{}
 	err := c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, currentSveltosCluster)
 	if err == nil {
 		// Update labels
-		return updateSveltosClusterLabels(ctx, c, currentSveltosCluster, labels)
+		return updateSveltosClusterLabelsAndAnnotations(ctx, c, currentSveltosCluster, labels, shard)
 	}
 
 	sveltosCluster := &libsveltosv1beta1.SveltosCluster{
@@ -393,6 +403,12 @@ func createSveltosCluster(ctx context.Context, c client.Client, namespace, name 
 		Spec: libsveltosv1beta1.SveltosClusterSpec{
 			PullMode: true,
 		},
+	}
+
+	if shard != "" {
+		sveltosCluster.Annotations = map[string]string{
+			"sharding.projectsveltos.io/key": shard,
+		}
 	}
 
 	err = c.Create(ctx, sveltosCluster)


### PR DESCRIPTION
```bash
Usage:
  sveltosctl register cluster [options] --namespace=<name> --cluster=<name> [--kubeconfig=<file>] [--fleet-cluster-context=<value>] [--pullmode]
                                [--labels=<value>] [--shard=<key>] [--service-account-token] [--verbose]

     --namespace=<name>                  Specifies the namespace where Sveltos will create a resource (SveltosCluster) to represent
                                         the registered cluster.
     --cluster=<name>                    Defines a name for the registered cluster within Sveltos.
     --kubeconfig=<file>                 (Optional) Provides the path to a file containing the kubeconfig for the Kubernetes cluster
                                         you want to register.
                                         If you don't have a kubeconfig file yet, you can use the "sveltosctl generate kubeconfig"
                                         command.
                                         Be sure to point that command to the specific cluster you want to manage.
                                         This will help you create the necessary kubeconfig file before registering the cluster
                                         with Sveltos.
                                         Either --kubeconfig or --fleet-cluster-context must be provided.
     --fleet-cluster-context=<value>     (Optional) If your kubeconfig has multiple contexts:
                                         - One context points to the management cluster (default one)
                                         - Another context points to the cluster you actually want to manage;
                                         In this case, you can specify the context name with the --fleet-cluster-context flag.
                                         This tells the command to use the specific context to generate a Kubeconfig Sveltos
                                         can use and then create a SveltosCluster with it so you don't have to provide kubeconfig
                                         Either --kubeconfig or --fleet-cluster-context must be provided.
     --pullmode                          (Optional) this registers a cluster in pull mode. When enabled, the managed cluster will actively
                                         fetch its configurations from the management cluster, which is ideal for scenarios with
                                         firewall restrictions or when direct inbound access to the managed cluster is undesirable.
                                         This flag outputs the specialized YAML configuration that needs to be applied to the managed
                                         cluster to complete its setup.
     --labels=<key1=value1,key2=value2>  (Optional) This option allows you to specify labels for the SveltosCluster resource
                                         being created. The format for labels is <key1=value1,key2=value2>, where each key-value
                                         pair is separated by a comma (,) and the key and value are separated by an equal sign (=).
                                         You can define multiple labels by adding more key-value pairs separated by commas.
     --shard=<shard key>                 Optional. Assigns the cluster to a specific controller shard. This automatically adds the annotation
                                         sharding.projectsveltos.io/key: <value> to the SveltosCluster resource, ensuring the correct shard
                                         processes it.
     --service-account-token             (Optional) Use a non-expiring ServiceAccount token for management cluster registration.
                                         When enabled, Sveltos will automatically create the necessary ServiceAccount infrastructure
                                         (ServiceAccount, ClusterRole, and ClusterRoleBinding) in the managed cluster and
                                         generate a long-lived token by also creating a Secret of type kubernetes.io/service-account-token.
```

Fixes #428 