### PR TITLE
(feat) Split register cluster workload identity flags into per-provider subcommands

### DIFF
--- a/internal/commands/onboard/cluster.go
+++ b/internal/commands/onboard/cluster.go
@@ -150,14 +150,9 @@ func patchSecret(ctx context.Context, clusterNamespace, secretName string, kubec
 }
 
 // RegisterCluster takes care of creating all necessary internal resources to import a cluster
-func RegisterCluster(ctx context.Context, args []string, logger logr.Logger) error { //nolint: funlen,gocyclo,maintidx // command description
+func RegisterCluster(ctx context.Context, args []string, logger logr.Logger) error { //nolint: funlen // command description
 	doc := `Usage:
   sveltosctl register cluster [options] --namespace=<name> --cluster=<name> [--kubeconfig=<file>] [--fleet-cluster-context=<value>] [--pullmode]
-                                [--workload-identity-provider=<name>] [--workload-identity-endpoint=<url>] [--workload-identity-ca-file=<file>]
-                                [--aws-cluster-name=<name>] [--aws-role-arn=<arn>] [--aws-region=<region>]
-                                [--gcp-project-id=<id>] [--gcp-cluster-name=<name>] [--gcp-location=<location>]
-                                [--azure-tenant-id=<id>] [--azure-client-id=<id>] [--azure-subscription-id=<id>]
-                                [--azure-resource-group=<group>] [--azure-cluster-name=<name>]
                                 [--labels=<value>] [--shard=<key>] [--service-account-token] [--verbose]
 
      --namespace=<name>                  Specifies the namespace where Sveltos will create a resource (SveltosCluster) to represent
@@ -183,31 +178,6 @@ func RegisterCluster(ctx context.Context, args []string, logger logr.Logger) err
                                          firewall restrictions or when direct inbound access to the managed cluster is undesirable.
                                          This flag outputs the specialized YAML configuration that needs to be applied to the managed
                                          cluster to complete its setup.
-     --workload-identity-provider=<name> (Optional) Cloud provider for workload identity authentication. One of: aws, gcp, azure.
-                                         When set, --kubeconfig and --fleet-cluster-context are not used; Sveltos obtains
-                                         short-lived credentials from the cloud provider at runtime.
-                                         Mutually exclusive with --kubeconfig and --fleet-cluster-context.
-     --workload-identity-endpoint=<url>  Required when --workload-identity-provider is set. The API server endpoint of the
-                                         managed cluster (e.g. https://...).
-     --workload-identity-ca-file=<file>  (Optional) Path to the CA certificate file for the managed cluster API server.
-                                         When provided, sveltosctl creates a Secret named <cluster>-sveltos-ca in the
-                                         cluster namespace and references it in the SveltosCluster.
-     --aws-cluster-name=<name>           Required when --workload-identity-provider=aws. The EKS cluster name, embedded
-                                         in the bearer token header sent to the EKS API server.
-     --aws-role-arn=<arn>                (Optional) IAM role ARN to assume before generating the EKS bearer token.
-                                         If omitted, the pod's own IRSA credentials are used directly.
-     --aws-region=<region>               (Optional) AWS region of the EKS cluster. Defaults to the AWS_REGION environment
-                                         variable injected by IRSA.
-     --gcp-project-id=<id>               Required when --workload-identity-provider=gcp. The GCP project ID.
-     --gcp-cluster-name=<name>           Required when --workload-identity-provider=gcp. The GKE cluster name.
-     --gcp-location=<location>           Required when --workload-identity-provider=gcp. The GCP region or zone
-                                         (e.g. us-central1-a).
-     --azure-tenant-id=<id>              Required when --workload-identity-provider=azure. Azure AD tenant ID.
-     --azure-client-id=<id>              Required when --workload-identity-provider=azure. Client ID of the managed
-                                         identity or app registration federated with the management cluster service account.
-     --azure-subscription-id=<id>        (Optional) Azure subscription containing the AKS cluster.
-     --azure-resource-group=<group>      (Optional) Azure resource group containing the AKS cluster.
-     --azure-cluster-name=<name>         (Optional) AKS cluster name.
      --labels=<key1=value1,key2=value2>  (Optional) This option allows you to specify labels for the SveltosCluster resource
                                          being created. The format for labels is <key1=value1,key2=value2>, where each key-value
                                          pair is separated by a comma (,) and the key and value are separated by an equal sign (=).
@@ -225,7 +195,9 @@ Options:
      --verbose               Verbose mode. Print each step.
 
 Description:
-  The register cluster command registers a cluster to be managed by Sveltos.
+  The register cluster command registers a cluster to be managed by Sveltos using a kubeconfig.
+  To register an EKS, GKE, or AKS cluster using workload identity, use the register cluster-eks,
+  register cluster-gke, or register cluster-aks commands instead.
 `
 	parsedArgs, err := docopt.ParseArgs(doc, nil, "1.0")
 	if err != nil {
@@ -241,10 +213,8 @@ Description:
 	}
 
 	_ = flag.Lookup("v").Value.Set(fmt.Sprint(logs.LogInfo))
-	verbose := parsedArgs["--verbose"].(bool)
-	if verbose {
-		err = flag.Lookup("v").Value.Set(fmt.Sprint(logs.LogDebug))
-		if err != nil {
+	if parsedArgs["--verbose"].(bool) {
+		if err := flag.Lookup("v").Value.Set(fmt.Sprint(logs.LogDebug)); err != nil {
 			return err
 		}
 	}
@@ -272,20 +242,20 @@ Description:
 		shard = passedShard.(string)
 	}
 
-	_ = flag.Lookup("v").Value.Set(fmt.Sprint(logs.LogInfo))
 	pullMode := parsedArgs["--pullmode"].(bool)
+	if pullMode {
+		return onboardSveltosClusterInPullMode(ctx, namespace, cluster, shard, labels, logger)
+	}
 
 	renew := true
-
 	satoken := parsedArgs["--service-account-token"].(bool)
 	if satoken {
 		renew = false
 	}
 
-	kubeconfig := ""
+	kubeconfigFile := ""
 	if passedKubeconfig := parsedArgs["--kubeconfig"]; passedKubeconfig != nil {
-		kubeconfig = passedKubeconfig.(string)
-		// If Kubeconfig is passed, dont try to renew it
+		kubeconfigFile = passedKubeconfig.(string)
 		renew = false
 		satoken = false
 	}
@@ -295,31 +265,11 @@ Description:
 		fleetClusterContext = passedContext.(string)
 	}
 
-	if pullMode {
-		return onboardSveltosClusterInPullMode(ctx, namespace, cluster, shard, labels, logger)
-	}
-
-	wiProvider := ""
-	if v := parsedArgs["--workload-identity-provider"]; v != nil {
-		wiProvider = v.(string)
-	}
-
-	if wiProvider != "" {
-		if kubeconfig != "" || fleetClusterContext != "" {
-			return fmt.Errorf("--workload-identity-provider is mutually exclusive with --kubeconfig and --fleet-cluster-context")
-		}
-		wi, caFile, err := buildWorkloadIdentityConfig(parsedArgs)
-		if err != nil {
-			return err
-		}
-		return onboardSveltosClusterWithWorkloadIdentity(ctx, namespace, cluster, shard, wi, caFile, labels, logger)
-	}
-
-	if kubeconfig == "" && fleetClusterContext == "" {
+	if kubeconfigFile == "" && fleetClusterContext == "" {
 		return fmt.Errorf("either kubeconfig or fleet-cluster-context must be specified")
 	}
 
-	data, err := getKubeconfigData(ctx, kubeconfig, fleetClusterContext, satoken, logger)
+	data, err := getKubeconfigData(ctx, kubeconfigFile, fleetClusterContext, satoken, logger)
 	if err != nil {
 		return err
 	}
@@ -418,113 +368,6 @@ func patchCASecret(ctx context.Context, clusterNamespace, secretName string, caD
 	logger.V(logs.LogDebug).Info(fmt.Sprintf("Updating CA Secret %s/%s", clusterNamespace, secretName))
 	current.Data = map[string][]byte{caKey: caData}
 	return instance.UpdateResource(ctx, current)
-}
-
-func buildWorkloadIdentityConfig(parsedArgs map[string]interface{}) (*libsveltosv1beta1.WorkloadIdentityConfig, string, error) {
-	endpoint := ""
-	if v := parsedArgs["--workload-identity-endpoint"]; v != nil {
-		endpoint = v.(string)
-	}
-	if endpoint == "" {
-		return nil, "", fmt.Errorf("--workload-identity-endpoint is required when --workload-identity-provider is set")
-	}
-
-	caFile := ""
-	if v := parsedArgs["--workload-identity-ca-file"]; v != nil {
-		caFile = v.(string)
-	}
-
-	provider := parsedArgs["--workload-identity-provider"].(string)
-	wi := &libsveltosv1beta1.WorkloadIdentityConfig{Endpoint: endpoint}
-
-	switch provider {
-	case "aws":
-		if err := buildAWSWorkloadIdentity(parsedArgs, wi); err != nil {
-			return nil, "", err
-		}
-	case "gcp":
-		if err := buildGCPWorkloadIdentity(parsedArgs, wi); err != nil {
-			return nil, "", err
-		}
-	case "azure":
-		if err := buildAzureWorkloadIdentity(parsedArgs, wi); err != nil {
-			return nil, "", err
-		}
-	default:
-		return nil, "", fmt.Errorf("unknown workload identity provider %q: must be aws, gcp, or azure", provider)
-	}
-
-	return wi, caFile, nil
-}
-
-func buildAWSWorkloadIdentity(parsedArgs map[string]interface{}, wi *libsveltosv1beta1.WorkloadIdentityConfig) error {
-	clusterName := ""
-	if v := parsedArgs["--aws-cluster-name"]; v != nil {
-		clusterName = v.(string)
-	}
-	if clusterName == "" {
-		return fmt.Errorf("--aws-cluster-name is required when --workload-identity-provider=aws")
-	}
-	wi.Provider = libsveltosv1beta1.WorkloadIdentityProviderAWS
-	wi.AWS = &libsveltosv1beta1.AWSWorkloadIdentityConfig{ClusterName: clusterName}
-	if v := parsedArgs["--aws-role-arn"]; v != nil {
-		wi.AWS.RoleARN = v.(string)
-	}
-	if v := parsedArgs["--aws-region"]; v != nil {
-		wi.AWS.Region = v.(string)
-	}
-	return nil
-}
-
-func buildGCPWorkloadIdentity(parsedArgs map[string]interface{}, wi *libsveltosv1beta1.WorkloadIdentityConfig) error {
-	projectID, clusterName, location := "", "", ""
-	if v := parsedArgs["--gcp-project-id"]; v != nil {
-		projectID = v.(string)
-	}
-	if v := parsedArgs["--gcp-cluster-name"]; v != nil {
-		clusterName = v.(string)
-	}
-	if v := parsedArgs["--gcp-location"]; v != nil {
-		location = v.(string)
-	}
-	if projectID == "" || clusterName == "" || location == "" {
-		return fmt.Errorf("--gcp-project-id, --gcp-cluster-name, and --gcp-location are required when --workload-identity-provider=gcp")
-	}
-	wi.Provider = libsveltosv1beta1.WorkloadIdentityProviderGCP
-	wi.GCP = &libsveltosv1beta1.GCPWorkloadIdentityConfig{
-		ProjectID:   projectID,
-		ClusterName: clusterName,
-		Location:    location,
-	}
-	return nil
-}
-
-func buildAzureWorkloadIdentity(parsedArgs map[string]interface{}, wi *libsveltosv1beta1.WorkloadIdentityConfig) error {
-	tenantID, clientID := "", ""
-	if v := parsedArgs["--azure-tenant-id"]; v != nil {
-		tenantID = v.(string)
-	}
-	if v := parsedArgs["--azure-client-id"]; v != nil {
-		clientID = v.(string)
-	}
-	if tenantID == "" || clientID == "" {
-		return fmt.Errorf("--azure-tenant-id and --azure-client-id are required when --workload-identity-provider=azure")
-	}
-	wi.Provider = libsveltosv1beta1.WorkloadIdentityProviderAzure
-	wi.Azure = &libsveltosv1beta1.AzureWorkloadIdentityConfig{
-		TenantID: tenantID,
-		ClientID: clientID,
-	}
-	if v := parsedArgs["--azure-subscription-id"]; v != nil {
-		wi.Azure.SubscriptionID = v.(string)
-	}
-	if v := parsedArgs["--azure-resource-group"]; v != nil {
-		wi.Azure.ResourceGroup = v.(string)
-	}
-	if v := parsedArgs["--azure-cluster-name"]; v != nil {
-		wi.Azure.ClusterName = v.(string)
-	}
-	return nil
 }
 
 func getKubeconfigData(ctx context.Context, kubeconfigFile, fleetClusterContext string,

--- a/internal/commands/onboard/cluster_aks.go
+++ b/internal/commands/onboard/cluster_aks.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2026. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package onboard
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/docopt/docopt-go"
+	"github.com/go-logr/logr"
+
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
+	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
+)
+
+func buildAKSWorkloadIdentityConfig(
+	endpoint, tenantID, clientID, subscriptionID, resourceGroup, aksClusterName string,
+) (*libsveltosv1beta1.WorkloadIdentityConfig, error) {
+
+	if endpoint == "" {
+		return nil, fmt.Errorf("--endpoint is required")
+	}
+	if tenantID == "" {
+		return nil, fmt.Errorf("--tenant-id is required")
+	}
+	if clientID == "" {
+		return nil, fmt.Errorf("--client-id is required")
+	}
+	wi := &libsveltosv1beta1.WorkloadIdentityConfig{
+		Provider: libsveltosv1beta1.WorkloadIdentityProviderAzure,
+		Endpoint: endpoint,
+		Azure: &libsveltosv1beta1.AzureWorkloadIdentityConfig{
+			TenantID:       tenantID,
+			ClientID:       clientID,
+			SubscriptionID: subscriptionID,
+			ResourceGroup:  resourceGroup,
+			ClusterName:    aksClusterName,
+		},
+	}
+	return wi, nil
+}
+
+// RegisterClusterAKS registers an Azure AKS cluster using workload identity.
+func RegisterClusterAKS(ctx context.Context, args []string, logger logr.Logger) error { //nolint: funlen // per-provider command
+	doc := `Usage:
+  sveltosctl register cluster-aks [options] --namespace=<name> --cluster=<name> --endpoint=<url>
+                                  --tenant-id=<id> --client-id=<id>
+                                  [--subscription-id=<id>] [--resource-group=<group>] [--aks-cluster-name=<name>]
+                                  [--ca-file=<file>] [--labels=<value>] [--shard=<key>] [--verbose]
+
+     --namespace=<name>           Namespace where Sveltos will create the SveltosCluster resource.
+     --cluster=<name>             Name for the registered cluster within Sveltos.
+     --endpoint=<url>             API server endpoint of the AKS cluster (e.g. https://my-aks.hcp.eastus.azmk8s.io).
+     --tenant-id=<id>             Azure AD tenant ID.
+     --client-id=<id>             Client ID of the managed identity or app registration federated with
+                                  the management cluster service account.
+     --subscription-id=<id>       (Optional) Azure subscription containing the AKS cluster.
+     --resource-group=<group>     (Optional) Azure resource group containing the AKS cluster.
+     --aks-cluster-name=<name>    (Optional) AKS cluster name.
+     --ca-file=<file>             (Optional) Path to the CA certificate file for the AKS API server.
+                                  When provided, sveltosctl stores the CA in a Secret and references it
+                                  in the SveltosCluster.
+     --labels=<key1=value1,...>   (Optional) Labels for the SveltosCluster resource (comma-separated key=value pairs).
+     --shard=<shard key>          (Optional) Assigns the cluster to a specific controller shard.
+
+Options:
+  -h --help                  Show this screen.
+     --verbose               Verbose mode. Print each step.
+
+Description:
+  The register cluster-aks command registers an Azure AKS cluster using workload identity federation.
+  Sveltos obtains short-lived credentials from Azure at runtime; no long-lived kubeconfig is stored.
+`
+	parsedArgs, err := docopt.ParseArgs(doc, nil, "1.0")
+	if err != nil {
+		logger.V(logs.LogInfo).Error(err, "failed to parse args")
+		return fmt.Errorf(
+			"invalid option: 'sveltosctl %s'. Use flag '--help' to read about a specific subcommand. Error: %w",
+			strings.Join(args, " "),
+			err,
+		)
+	}
+	if len(parsedArgs) == 0 {
+		return nil
+	}
+
+	_ = flag.Lookup("v").Value.Set(fmt.Sprint(logs.LogInfo))
+	if parsedArgs["--verbose"].(bool) {
+		if err := flag.Lookup("v").Value.Set(fmt.Sprint(logs.LogDebug)); err != nil {
+			return err
+		}
+	}
+
+	namespace := ""
+	if v := parsedArgs["--namespace"]; v != nil {
+		namespace = v.(string)
+	}
+	cluster := ""
+	if v := parsedArgs["--cluster"]; v != nil {
+		cluster = v.(string)
+	}
+	endpoint := ""
+	if v := parsedArgs["--endpoint"]; v != nil {
+		endpoint = v.(string)
+	}
+	tenantID := ""
+	if v := parsedArgs["--tenant-id"]; v != nil {
+		tenantID = v.(string)
+	}
+	clientID := ""
+	if v := parsedArgs["--client-id"]; v != nil {
+		clientID = v.(string)
+	}
+	subscriptionID := ""
+	if v := parsedArgs["--subscription-id"]; v != nil {
+		subscriptionID = v.(string)
+	}
+	resourceGroup := ""
+	if v := parsedArgs["--resource-group"]; v != nil {
+		resourceGroup = v.(string)
+	}
+	aksClusterName := ""
+	if v := parsedArgs["--aks-cluster-name"]; v != nil {
+		aksClusterName = v.(string)
+	}
+	caFile := ""
+	if v := parsedArgs["--ca-file"]; v != nil {
+		caFile = v.(string)
+	}
+	shard := ""
+	if v := parsedArgs["--shard"]; v != nil {
+		shard = v.(string)
+	}
+	var labels map[string]string
+	if v := parsedArgs["--labels"]; v != nil {
+		labels, err = stringToMap(v.(string))
+		if err != nil {
+			return err
+		}
+	}
+
+	wi, err := buildAKSWorkloadIdentityConfig(endpoint, tenantID, clientID, subscriptionID, resourceGroup, aksClusterName)
+	if err != nil {
+		return err
+	}
+	return onboardSveltosClusterWithWorkloadIdentity(ctx, namespace, cluster, shard, wi, caFile, labels, logger)
+}

--- a/internal/commands/onboard/cluster_eks.go
+++ b/internal/commands/onboard/cluster_eks.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2026. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package onboard
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/docopt/docopt-go"
+	"github.com/go-logr/logr"
+
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
+	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
+)
+
+func buildEKSWorkloadIdentityConfig(endpoint, eksClusterName, roleARN, region string) (*libsveltosv1beta1.WorkloadIdentityConfig, error) {
+	if endpoint == "" {
+		return nil, fmt.Errorf("--endpoint is required")
+	}
+	if eksClusterName == "" {
+		return nil, fmt.Errorf("--eks-cluster-name is required")
+	}
+	wi := &libsveltosv1beta1.WorkloadIdentityConfig{
+		Provider: libsveltosv1beta1.WorkloadIdentityProviderAWS,
+		Endpoint: endpoint,
+		AWS: &libsveltosv1beta1.AWSWorkloadIdentityConfig{
+			ClusterName: eksClusterName,
+			RoleARN:     roleARN,
+			Region:      region,
+		},
+	}
+	return wi, nil
+}
+
+// RegisterClusterEKS registers an Amazon EKS cluster using workload identity.
+func RegisterClusterEKS(ctx context.Context, args []string, logger logr.Logger) error { //nolint: dupl // per-provider command
+	doc := `Usage:
+  sveltosctl register cluster-eks [options] --namespace=<name> --cluster=<name> --endpoint=<url> --eks-cluster-name=<name>
+                                  [--role-arn=<arn>] [--region=<region>] [--ca-file=<file>]
+                                  [--labels=<value>] [--shard=<key>] [--verbose]
+
+     --namespace=<name>           Namespace where Sveltos will create the SveltosCluster resource.
+     --cluster=<name>             Name for the registered cluster within Sveltos.
+     --endpoint=<url>             API server endpoint of the EKS cluster (e.g. https://...).
+     --eks-cluster-name=<name>    EKS cluster name, embedded in the bearer token sent to the EKS API server.
+     --role-arn=<arn>             (Optional) IAM role ARN to assume before generating the EKS bearer token.
+                                  If omitted, the pod's own IRSA credentials are used directly.
+     --region=<region>            (Optional) AWS region of the EKS cluster. Defaults to the AWS_REGION
+                                  environment variable injected by IRSA.
+     --ca-file=<file>             (Optional) Path to the CA certificate file for the EKS API server.
+                                  When provided, sveltosctl stores the CA in a Secret and references it
+                                  in the SveltosCluster.
+     --labels=<key1=value1,...>   (Optional) Labels for the SveltosCluster resource (comma-separated key=value pairs).
+     --shard=<shard key>          (Optional) Assigns the cluster to a specific controller shard.
+
+Options:
+  -h --help                  Show this screen.
+     --verbose               Verbose mode. Print each step.
+
+Description:
+  The register cluster-eks command registers an Amazon EKS cluster using workload identity (IRSA).
+  Sveltos obtains short-lived credentials from AWS at runtime; no long-lived kubeconfig is stored.
+`
+	parsedArgs, err := docopt.ParseArgs(doc, nil, "1.0")
+	if err != nil {
+		logger.V(logs.LogInfo).Error(err, "failed to parse args")
+		return fmt.Errorf(
+			"invalid option: 'sveltosctl %s'. Use flag '--help' to read about a specific subcommand. Error: %w",
+			strings.Join(args, " "),
+			err,
+		)
+	}
+	if len(parsedArgs) == 0 {
+		return nil
+	}
+
+	_ = flag.Lookup("v").Value.Set(fmt.Sprint(logs.LogInfo))
+	if parsedArgs["--verbose"].(bool) {
+		if err := flag.Lookup("v").Value.Set(fmt.Sprint(logs.LogDebug)); err != nil {
+			return err
+		}
+	}
+
+	namespace := ""
+	if v := parsedArgs["--namespace"]; v != nil {
+		namespace = v.(string)
+	}
+	cluster := ""
+	if v := parsedArgs["--cluster"]; v != nil {
+		cluster = v.(string)
+	}
+	endpoint := ""
+	if v := parsedArgs["--endpoint"]; v != nil {
+		endpoint = v.(string)
+	}
+	eksClusterName := ""
+	if v := parsedArgs["--eks-cluster-name"]; v != nil {
+		eksClusterName = v.(string)
+	}
+	roleARN := ""
+	if v := parsedArgs["--role-arn"]; v != nil {
+		roleARN = v.(string)
+	}
+	region := ""
+	if v := parsedArgs["--region"]; v != nil {
+		region = v.(string)
+	}
+	caFile := ""
+	if v := parsedArgs["--ca-file"]; v != nil {
+		caFile = v.(string)
+	}
+	shard := ""
+	if v := parsedArgs["--shard"]; v != nil {
+		shard = v.(string)
+	}
+	var labels map[string]string
+	if v := parsedArgs["--labels"]; v != nil {
+		labels, err = stringToMap(v.(string))
+		if err != nil {
+			return err
+		}
+	}
+
+	wi, err := buildEKSWorkloadIdentityConfig(endpoint, eksClusterName, roleARN, region)
+	if err != nil {
+		return err
+	}
+	return onboardSveltosClusterWithWorkloadIdentity(ctx, namespace, cluster, shard, wi, caFile, labels, logger)
+}

--- a/internal/commands/onboard/cluster_gke.go
+++ b/internal/commands/onboard/cluster_gke.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2026. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package onboard
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/docopt/docopt-go"
+	"github.com/go-logr/logr"
+
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
+	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
+)
+
+func buildGKEWorkloadIdentityConfig(endpoint, projectID, gkeClusterName, location string) (*libsveltosv1beta1.WorkloadIdentityConfig, error) {
+	if endpoint == "" {
+		return nil, fmt.Errorf("--endpoint is required")
+	}
+	if projectID == "" {
+		return nil, fmt.Errorf("--project-id is required")
+	}
+	if gkeClusterName == "" {
+		return nil, fmt.Errorf("--gke-cluster-name is required")
+	}
+	if location == "" {
+		return nil, fmt.Errorf("--location is required")
+	}
+	wi := &libsveltosv1beta1.WorkloadIdentityConfig{
+		Provider: libsveltosv1beta1.WorkloadIdentityProviderGCP,
+		Endpoint: endpoint,
+		GCP: &libsveltosv1beta1.GCPWorkloadIdentityConfig{
+			ProjectID:   projectID,
+			ClusterName: gkeClusterName,
+			Location:    location,
+		},
+	}
+	return wi, nil
+}
+
+// RegisterClusterGKE registers a Google GKE cluster using workload identity.
+func RegisterClusterGKE(ctx context.Context, args []string, logger logr.Logger) error { //nolint: dupl // per-provider command
+	doc := `Usage:
+  sveltosctl register cluster-gke [options] --namespace=<name> --cluster=<name> --endpoint=<url>
+                                  --project-id=<id> --gke-cluster-name=<name> --location=<location>
+                                  [--ca-file=<file>] [--labels=<value>] [--shard=<key>] [--verbose]
+
+     --namespace=<name>           Namespace where Sveltos will create the SveltosCluster resource.
+     --cluster=<name>             Name for the registered cluster within Sveltos.
+     --endpoint=<url>             API server endpoint of the GKE cluster (e.g. https://34.x.x.x).
+     --project-id=<id>            GCP project ID containing the GKE cluster.
+     --gke-cluster-name=<name>    GKE cluster name.
+     --location=<location>        GCP region or zone of the GKE cluster (e.g. us-central1-a).
+     --ca-file=<file>             (Optional) Path to the CA certificate file for the GKE API server.
+                                  When provided, sveltosctl stores the CA in a Secret and references it
+                                  in the SveltosCluster.
+     --labels=<key1=value1,...>   (Optional) Labels for the SveltosCluster resource (comma-separated key=value pairs).
+     --shard=<shard key>          (Optional) Assigns the cluster to a specific controller shard.
+
+Options:
+  -h --help                  Show this screen.
+     --verbose               Verbose mode. Print each step.
+
+Description:
+  The register cluster-gke command registers a Google GKE cluster using workload identity federation.
+  Sveltos obtains short-lived credentials from GCP at runtime; no long-lived kubeconfig is stored.
+`
+	parsedArgs, err := docopt.ParseArgs(doc, nil, "1.0")
+	if err != nil {
+		logger.V(logs.LogInfo).Error(err, "failed to parse args")
+		return fmt.Errorf(
+			"invalid option: 'sveltosctl %s'. Use flag '--help' to read about a specific subcommand. Error: %w",
+			strings.Join(args, " "),
+			err,
+		)
+	}
+	if len(parsedArgs) == 0 {
+		return nil
+	}
+
+	_ = flag.Lookup("v").Value.Set(fmt.Sprint(logs.LogInfo))
+	if parsedArgs["--verbose"].(bool) {
+		if err := flag.Lookup("v").Value.Set(fmt.Sprint(logs.LogDebug)); err != nil {
+			return err
+		}
+	}
+
+	namespace := ""
+	if v := parsedArgs["--namespace"]; v != nil {
+		namespace = v.(string)
+	}
+	cluster := ""
+	if v := parsedArgs["--cluster"]; v != nil {
+		cluster = v.(string)
+	}
+	endpoint := ""
+	if v := parsedArgs["--endpoint"]; v != nil {
+		endpoint = v.(string)
+	}
+	projectID := ""
+	if v := parsedArgs["--project-id"]; v != nil {
+		projectID = v.(string)
+	}
+	gkeClusterName := ""
+	if v := parsedArgs["--gke-cluster-name"]; v != nil {
+		gkeClusterName = v.(string)
+	}
+	location := ""
+	if v := parsedArgs["--location"]; v != nil {
+		location = v.(string)
+	}
+	caFile := ""
+	if v := parsedArgs["--ca-file"]; v != nil {
+		caFile = v.(string)
+	}
+	shard := ""
+	if v := parsedArgs["--shard"]; v != nil {
+		shard = v.(string)
+	}
+	var labels map[string]string
+	if v := parsedArgs["--labels"]; v != nil {
+		labels, err = stringToMap(v.(string))
+		if err != nil {
+			return err
+		}
+	}
+
+	wi, err := buildGKEWorkloadIdentityConfig(endpoint, projectID, gkeClusterName, location)
+	if err != nil {
+		return err
+	}
+	return onboardSveltosClusterWithWorkloadIdentity(ctx, namespace, cluster, shard, wi, caFile, labels, logger)
+}

--- a/internal/commands/onboard/export_test.go
+++ b/internal/commands/onboard/export_test.go
@@ -19,7 +19,9 @@ package onboard
 var (
 	OnboardSveltosCluster                     = onboardSveltosCluster
 	OnboardSveltosClusterWithWorkloadIdentity = onboardSveltosClusterWithWorkloadIdentity
-	BuildWorkloadIdentityConfig               = buildWorkloadIdentityConfig
+	BuildEKSWorkloadIdentityConfig            = buildEKSWorkloadIdentityConfig
+	BuildGKEWorkloadIdentityConfig            = buildGKEWorkloadIdentityConfig
+	BuildAKSWorkloadIdentityConfig            = buildAKSWorkloadIdentityConfig
 	PrepareApplierYAML                        = prepareApplierYAML
 	DeregisterSveltosCluster                  = deregisterSveltosCluster
 	DeletePullModeResources                   = deletePullModeResources

--- a/internal/commands/onboard/workload_identity_test.go
+++ b/internal/commands/onboard/workload_identity_test.go
@@ -35,258 +35,124 @@ import (
 )
 
 const (
-	argWorkloadIdentityProvider = "--workload-identity-provider"
-	argWorkloadIdentityEndpoint = "--workload-identity-endpoint"
-	argWorkloadIdentityCAFile   = "--workload-identity-ca-file"
-	argAWSClusterName           = "--aws-cluster-name"
-	argAWSRoleARN               = "--aws-role-arn"
-	argAWSRegion                = "--aws-region"
-	argGCPProjectID             = "--gcp-project-id"
-	argGCPClusterName           = "--gcp-cluster-name"
-	argGCPLocation              = "--gcp-location"
-	argAzureTenantID            = "--azure-tenant-id"
-	argAzureClientID            = "--azure-client-id"
-	argAzureSubscriptionID      = "--azure-subscription-id"
-	argAzureResourceGroup       = "--azure-resource-group"
-	argAzureClusterName         = "--azure-cluster-name"
-	providerAWS                 = "aws"
-	clusterNameAWS              = "my-cluster"
-	endpointAWSEKS              = "https://example.eks.amazonaws.com"
-	clusterNameEKS              = "my-eks-cluster"
-	providerGCP                 = "gcp"
-	endpointGCP                 = "https://34.1.2.3"
-	projectIDGCP                = "my-project"
-	providerAzure               = "azure"
-	endpointAzure               = "https://my-aks.hcp.eastus.azmk8s.io"
-	tenantIDAzure               = "my-tenant"
+	endpointEKS    = "https://example.eks.amazonaws.com"
+	clusterNameEKS = "my-eks-cluster"
+	endpointGKE    = "https://34.1.2.3"
+	projectIDGKE   = "my-project"
+	endpointAKS    = "https://my-aks.hcp.eastus.azmk8s.io"
+	tenantIDAKS    = "my-tenant"
+	clientIDAKS    = "my-client"
 )
 
-var _ = Describe("BuildWorkloadIdentityConfig", func() {
-	logger := textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1)))
-	_ = logger
-
+var _ = Describe("BuildEKSWorkloadIdentityConfig", func() {
 	It("returns error when endpoint is missing", func() {
-		args := map[string]interface{}{
-			argWorkloadIdentityProvider: providerAWS,
-			argWorkloadIdentityEndpoint: nil,
-			argWorkloadIdentityCAFile:   nil,
-			argAWSClusterName:           clusterNameAWS,
-			argAWSRoleARN:               nil,
-			argAWSRegion:                nil,
-			argGCPProjectID:             nil,
-			argGCPClusterName:           nil,
-			argGCPLocation:              nil,
-			argAzureTenantID:            nil,
-			argAzureClientID:            nil,
-			argAzureSubscriptionID:      nil,
-			argAzureResourceGroup:       nil,
-			argAzureClusterName:         nil,
-		}
-		_, _, err := onboard.BuildWorkloadIdentityConfig(args)
+		_, err := onboard.BuildEKSWorkloadIdentityConfig("", clusterNameEKS, "", "")
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring(argWorkloadIdentityEndpoint))
+		Expect(err.Error()).To(ContainSubstring("--endpoint"))
 	})
 
-	It("returns error for unknown provider", func() {
-		args := map[string]interface{}{
-			argWorkloadIdentityProvider: "unknown",
-			argWorkloadIdentityEndpoint: "https://example.com",
-			argWorkloadIdentityCAFile:   nil,
-			argAWSClusterName:           nil,
-			argAWSRoleARN:               nil,
-			argAWSRegion:                nil,
-			argGCPProjectID:             nil,
-			argGCPClusterName:           nil,
-			argGCPLocation:              nil,
-			argAzureTenantID:            nil,
-			argAzureClientID:            nil,
-			argAzureSubscriptionID:      nil,
-			argAzureResourceGroup:       nil,
-			argAzureClusterName:         nil,
-		}
-		_, _, err := onboard.BuildWorkloadIdentityConfig(args)
+	It("returns error when eks-cluster-name is missing", func() {
+		_, err := onboard.BuildEKSWorkloadIdentityConfig(endpointEKS, "", "", "")
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("unknown"))
+		Expect(err.Error()).To(ContainSubstring("--eks-cluster-name"))
 	})
 
-	Context("AWS", func() {
-		It("returns error when --aws-cluster-name is missing", func() {
-			args := map[string]interface{}{
-				argWorkloadIdentityProvider: providerAWS,
-				argWorkloadIdentityEndpoint: endpointAWSEKS,
-				argWorkloadIdentityCAFile:   nil,
-				argAWSClusterName:           nil,
-				argAWSRoleARN:               nil,
-				argAWSRegion:                nil,
-				argGCPProjectID:             nil,
-				argGCPClusterName:           nil,
-				argGCPLocation:              nil,
-				argAzureTenantID:            nil,
-				argAzureClientID:            nil,
-				argAzureSubscriptionID:      nil,
-				argAzureResourceGroup:       nil,
-				argAzureClusterName:         nil,
-			}
-			_, _, err := onboard.BuildWorkloadIdentityConfig(args)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring(argAWSClusterName))
-		})
-
-		It("builds AWS config with required fields only", func() {
-			args := map[string]interface{}{
-				argWorkloadIdentityProvider: providerAWS,
-				argWorkloadIdentityEndpoint: endpointAWSEKS,
-				argWorkloadIdentityCAFile:   nil,
-				argAWSClusterName:           clusterNameEKS,
-				argAWSRoleARN:               nil,
-				argAWSRegion:                nil,
-				argGCPProjectID:             nil,
-				argGCPClusterName:           nil,
-				argGCPLocation:              nil,
-				argAzureTenantID:            nil,
-				argAzureClientID:            nil,
-				argAzureSubscriptionID:      nil,
-				argAzureResourceGroup:       nil,
-				argAzureClusterName:         nil,
-			}
-			wi, caFile, err := onboard.BuildWorkloadIdentityConfig(args)
-			Expect(err).To(BeNil())
-			Expect(caFile).To(BeEmpty())
-			Expect(wi.Provider).To(Equal(libsveltosv1beta1.WorkloadIdentityProviderAWS))
-			Expect(wi.Endpoint).To(Equal(endpointAWSEKS))
-			Expect(wi.AWS).ToNot(BeNil())
-			Expect(wi.AWS.ClusterName).To(Equal(clusterNameEKS))
-			Expect(wi.AWS.RoleARN).To(BeEmpty())
-			Expect(wi.AWS.Region).To(BeEmpty())
-		})
-
-		It("builds AWS config with all optional fields", func() {
-			args := map[string]interface{}{
-				argWorkloadIdentityProvider: providerAWS,
-				argWorkloadIdentityEndpoint: endpointAWSEKS,
-				argWorkloadIdentityCAFile:   "/tmp/ca.crt",
-				argAWSClusterName:           clusterNameEKS,
-				argAWSRoleARN:               "arn:aws:iam::123456789012:role/my-role",
-				argAWSRegion:                "us-east-1",
-				argGCPProjectID:             nil,
-				argGCPClusterName:           nil,
-				argGCPLocation:              nil,
-				argAzureTenantID:            nil,
-				argAzureClientID:            nil,
-				argAzureSubscriptionID:      nil,
-				argAzureResourceGroup:       nil,
-				argAzureClusterName:         nil,
-			}
-			wi, caFile, err := onboard.BuildWorkloadIdentityConfig(args)
-			Expect(err).To(BeNil())
-			Expect(caFile).To(Equal("/tmp/ca.crt"))
-			Expect(wi.AWS.RoleARN).To(Equal("arn:aws:iam::123456789012:role/my-role"))
-			Expect(wi.AWS.Region).To(Equal("us-east-1"))
-		})
+	It("builds config with required fields only", func() {
+		wi, err := onboard.BuildEKSWorkloadIdentityConfig(endpointEKS, clusterNameEKS, "", "")
+		Expect(err).To(BeNil())
+		Expect(wi.Provider).To(Equal(libsveltosv1beta1.WorkloadIdentityProviderAWS))
+		Expect(wi.Endpoint).To(Equal(endpointEKS))
+		Expect(wi.AWS).ToNot(BeNil())
+		Expect(wi.AWS.ClusterName).To(Equal(clusterNameEKS))
+		Expect(wi.AWS.RoleARN).To(BeEmpty())
+		Expect(wi.AWS.Region).To(BeEmpty())
 	})
 
-	Context("GCP", func() {
-		It("returns error when required GCP fields are missing", func() {
-			args := map[string]interface{}{
-				argWorkloadIdentityProvider: providerGCP,
-				argWorkloadIdentityEndpoint: endpointGCP,
-				argWorkloadIdentityCAFile:   nil,
-				argAWSClusterName:           nil,
-				argAWSRoleARN:               nil,
-				argAWSRegion:                nil,
-				argGCPProjectID:             projectIDGCP,
-				argGCPClusterName:           nil,
-				argGCPLocation:              nil,
-				argAzureTenantID:            nil,
-				argAzureClientID:            nil,
-				argAzureSubscriptionID:      nil,
-				argAzureResourceGroup:       nil,
-				argAzureClusterName:         nil,
-			}
-			_, _, err := onboard.BuildWorkloadIdentityConfig(args)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring(argGCPClusterName))
-		})
+	It("builds config with all optional fields", func() {
+		wi, err := onboard.BuildEKSWorkloadIdentityConfig(endpointEKS, clusterNameEKS,
+			"arn:aws:iam::123456789012:role/my-role", "us-east-1")
+		Expect(err).To(BeNil())
+		Expect(wi.AWS.RoleARN).To(Equal("arn:aws:iam::123456789012:role/my-role"))
+		Expect(wi.AWS.Region).To(Equal("us-east-1"))
+	})
+})
 
-		It("builds GCP config with all required fields", func() {
-			args := map[string]interface{}{
-				argWorkloadIdentityProvider: providerGCP,
-				argWorkloadIdentityEndpoint: endpointGCP,
-				argWorkloadIdentityCAFile:   nil,
-				argAWSClusterName:           nil,
-				argAWSRoleARN:               nil,
-				argAWSRegion:                nil,
-				argGCPProjectID:             projectIDGCP,
-				argGCPClusterName:           "cluster-managed",
-				argGCPLocation:              "us-central1-a",
-				argAzureTenantID:            nil,
-				argAzureClientID:            nil,
-				argAzureSubscriptionID:      nil,
-				argAzureResourceGroup:       nil,
-				argAzureClusterName:         nil,
-			}
-			wi, caFile, err := onboard.BuildWorkloadIdentityConfig(args)
-			Expect(err).To(BeNil())
-			Expect(caFile).To(BeEmpty())
-			Expect(wi.Provider).To(Equal(libsveltosv1beta1.WorkloadIdentityProviderGCP))
-			Expect(wi.GCP).ToNot(BeNil())
-			Expect(wi.GCP.ProjectID).To(Equal(projectIDGCP))
-			Expect(wi.GCP.ClusterName).To(Equal("cluster-managed"))
-			Expect(wi.GCP.Location).To(Equal("us-central1-a"))
-		})
+var _ = Describe("BuildGKEWorkloadIdentityConfig", func() {
+	It("returns error when endpoint is missing", func() {
+		_, err := onboard.BuildGKEWorkloadIdentityConfig("", projectIDGKE, "my-cluster", "us-central1-a")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("--endpoint"))
 	})
 
-	Context("Azure", func() {
-		It("returns error when required Azure fields are missing", func() {
-			args := map[string]interface{}{
-				argWorkloadIdentityProvider: providerAzure,
-				argWorkloadIdentityEndpoint: endpointAzure,
-				argWorkloadIdentityCAFile:   nil,
-				argAWSClusterName:           nil,
-				argAWSRoleARN:               nil,
-				argAWSRegion:                nil,
-				argGCPProjectID:             nil,
-				argGCPClusterName:           nil,
-				argGCPLocation:              nil,
-				argAzureTenantID:            tenantIDAzure,
-				argAzureClientID:            nil,
-				argAzureSubscriptionID:      nil,
-				argAzureResourceGroup:       nil,
-				argAzureClusterName:         nil,
-			}
-			_, _, err := onboard.BuildWorkloadIdentityConfig(args)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring(argAzureClientID))
-		})
+	It("returns error when project-id is missing", func() {
+		_, err := onboard.BuildGKEWorkloadIdentityConfig(endpointGKE, "", "my-cluster", "us-central1-a")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("--project-id"))
+	})
 
-		It("builds Azure config with required fields and optional fields", func() {
-			args := map[string]interface{}{
-				argWorkloadIdentityProvider: providerAzure,
-				argWorkloadIdentityEndpoint: endpointAzure,
-				argWorkloadIdentityCAFile:   nil,
-				argAWSClusterName:           nil,
-				argAWSRoleARN:               nil,
-				argAWSRegion:                nil,
-				argGCPProjectID:             nil,
-				argGCPClusterName:           nil,
-				argGCPLocation:              nil,
-				argAzureTenantID:            tenantIDAzure,
-				argAzureClientID:            "my-client",
-				argAzureSubscriptionID:      "my-sub",
-				argAzureResourceGroup:       "my-rg",
-				argAzureClusterName:         "my-aks",
-			}
-			wi, caFile, err := onboard.BuildWorkloadIdentityConfig(args)
-			Expect(err).To(BeNil())
-			Expect(caFile).To(BeEmpty())
-			Expect(wi.Provider).To(Equal(libsveltosv1beta1.WorkloadIdentityProviderAzure))
-			Expect(wi.Azure).ToNot(BeNil())
-			Expect(wi.Azure.TenantID).To(Equal(tenantIDAzure))
-			Expect(wi.Azure.ClientID).To(Equal("my-client"))
-			Expect(wi.Azure.SubscriptionID).To(Equal("my-sub"))
-			Expect(wi.Azure.ResourceGroup).To(Equal("my-rg"))
-			Expect(wi.Azure.ClusterName).To(Equal("my-aks"))
-		})
+	It("returns error when gke-cluster-name is missing", func() {
+		_, err := onboard.BuildGKEWorkloadIdentityConfig(endpointGKE, projectIDGKE, "", "us-central1-a")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("--gke-cluster-name"))
+	})
+
+	It("returns error when location is missing", func() {
+		_, err := onboard.BuildGKEWorkloadIdentityConfig(endpointGKE, projectIDGKE, "my-cluster", "")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("--location"))
+	})
+
+	It("builds config with all required fields", func() {
+		wi, err := onboard.BuildGKEWorkloadIdentityConfig(endpointGKE, projectIDGKE, "cluster-managed", "us-central1-a")
+		Expect(err).To(BeNil())
+		Expect(wi.Provider).To(Equal(libsveltosv1beta1.WorkloadIdentityProviderGCP))
+		Expect(wi.Endpoint).To(Equal(endpointGKE))
+		Expect(wi.GCP).ToNot(BeNil())
+		Expect(wi.GCP.ProjectID).To(Equal(projectIDGKE))
+		Expect(wi.GCP.ClusterName).To(Equal("cluster-managed"))
+		Expect(wi.GCP.Location).To(Equal("us-central1-a"))
+	})
+})
+
+var _ = Describe("BuildAKSWorkloadIdentityConfig", func() {
+	It("returns error when endpoint is missing", func() {
+		_, err := onboard.BuildAKSWorkloadIdentityConfig("", tenantIDAKS, clientIDAKS, "", "", "")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("--endpoint"))
+	})
+
+	It("returns error when tenant-id is missing", func() {
+		_, err := onboard.BuildAKSWorkloadIdentityConfig(endpointAKS, "", clientIDAKS, "", "", "")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("--tenant-id"))
+	})
+
+	It("returns error when client-id is missing", func() {
+		_, err := onboard.BuildAKSWorkloadIdentityConfig(endpointAKS, tenantIDAKS, "", "", "", "")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("--client-id"))
+	})
+
+	It("builds config with required fields only", func() {
+		wi, err := onboard.BuildAKSWorkloadIdentityConfig(endpointAKS, tenantIDAKS, clientIDAKS, "", "", "")
+		Expect(err).To(BeNil())
+		Expect(wi.Provider).To(Equal(libsveltosv1beta1.WorkloadIdentityProviderAzure))
+		Expect(wi.Endpoint).To(Equal(endpointAKS))
+		Expect(wi.Azure).ToNot(BeNil())
+		Expect(wi.Azure.TenantID).To(Equal(tenantIDAKS))
+		Expect(wi.Azure.ClientID).To(Equal(clientIDAKS))
+		Expect(wi.Azure.SubscriptionID).To(BeEmpty())
+		Expect(wi.Azure.ResourceGroup).To(BeEmpty())
+		Expect(wi.Azure.ClusterName).To(BeEmpty())
+	})
+
+	It("builds config with all optional fields", func() {
+		wi, err := onboard.BuildAKSWorkloadIdentityConfig(endpointAKS, tenantIDAKS, clientIDAKS,
+			"my-sub", "my-rg", "my-aks")
+		Expect(err).To(BeNil())
+		Expect(wi.Azure.SubscriptionID).To(Equal("my-sub"))
+		Expect(wi.Azure.ResourceGroup).To(Equal("my-rg"))
+		Expect(wi.Azure.ClusterName).To(Equal("my-aks"))
 	})
 })
 
@@ -310,7 +176,7 @@ var _ = Describe("OnboardSveltosClusterWithWorkloadIdentity", func() {
 	awsWI := func() *libsveltosv1beta1.WorkloadIdentityConfig {
 		return &libsveltosv1beta1.WorkloadIdentityConfig{
 			Provider: libsveltosv1beta1.WorkloadIdentityProviderAWS,
-			Endpoint: endpointAWSEKS,
+			Endpoint: endpointEKS,
 			AWS: &libsveltosv1beta1.AWSWorkloadIdentityConfig{
 				ClusterName: clusterNameEKS,
 			},
@@ -331,7 +197,6 @@ var _ = Describe("OnboardSveltosClusterWithWorkloadIdentity", func() {
 		Expect(sc.Spec.WorkloadIdentity.Provider).To(Equal(libsveltosv1beta1.WorkloadIdentityProviderAWS))
 		Expect(sc.Spec.KubeconfigKeyName).To(BeEmpty())
 
-		// no kubeconfig secret created
 		secret := &corev1.Secret{}
 		secretName := clusterName + onboard.SveltosKubeconfigSecretNamePostfix
 		err := instance.GetResource(context.TODO(),
@@ -369,12 +234,10 @@ var _ = Describe("OnboardSveltosClusterWithWorkloadIdentity", func() {
 	})
 
 	It("updates existing SveltosCluster and clears KubeconfigKeyName", func() {
-		// first register with kubeconfig
 		Expect(onboard.OnboardSveltosCluster(
 			context.TODO(), clusterNamespace, clusterName, "", []byte("kubeconfig-data"), nil, false, logger,
 		)).To(Succeed())
 
-		// then re-register with workload identity
 		Expect(onboard.OnboardSveltosClusterWithWorkloadIdentity(
 			context.TODO(), clusterNamespace, clusterName, "", awsWI(), "", nil, logger,
 		)).To(Succeed())
@@ -408,9 +271,9 @@ var _ = Describe("DeregisterSveltosCluster workload identity", func() {
 		sc.Name = clusterName
 		sc.Spec.WorkloadIdentity = &libsveltosv1beta1.WorkloadIdentityConfig{
 			Provider:    libsveltosv1beta1.WorkloadIdentityProviderAWS,
-			Endpoint:    endpointAWSEKS,
+			Endpoint:    endpointEKS,
 			CASecretRef: &corev1.LocalObjectReference{Name: caSecretName},
-			AWS:         &libsveltosv1beta1.AWSWorkloadIdentityConfig{ClusterName: clusterNameAWS},
+			AWS:         &libsveltosv1beta1.AWSWorkloadIdentityConfig{ClusterName: clusterNameEKS},
 		}
 
 		scheme, err := utils.GetScheme()
@@ -422,17 +285,14 @@ var _ = Describe("DeregisterSveltosCluster workload identity", func() {
 
 		instance := utils.GetAccessInstance()
 
-		// SveltosCluster deleted
 		err = instance.GetResource(context.TODO(),
 			types.NamespacedName{Namespace: clusterNamespace, Name: clusterName}, &libsveltosv1beta1.SveltosCluster{})
 		Expect(apierrors.IsNotFound(err)).To(BeTrue())
 
-		// CA secret deleted
 		err = instance.GetResource(context.TODO(),
 			types.NamespacedName{Namespace: clusterNamespace, Name: caSecretName}, &corev1.Secret{})
 		Expect(apierrors.IsNotFound(err)).To(BeTrue())
 
-		// kubeconfig secret was never created — still not found (not an error condition)
 		kubeconfigSecretName := clusterName + onboard.SveltosKubeconfigSecretNamePostfix
 		err = instance.GetResource(context.TODO(),
 			types.NamespacedName{Namespace: clusterNamespace, Name: kubeconfigSecretName}, &corev1.Secret{})

--- a/internal/commands/register_cluster.go
+++ b/internal/commands/register_cluster.go
@@ -35,7 +35,10 @@ func RegisterCluster(ctx context.Context, args []string, logger logr.Logger) err
 	doc := `Usage:
 	sveltosctl register <command> [<args>...]
 
-	cluster       Imports a non CAPI cluster to be managed by Sveltos.
+	cluster       Registers a cluster using a kubeconfig or context.
+	cluster-eks   Registers an Amazon EKS cluster using workload identity (IRSA).
+	cluster-gke   Registers a Google GKE cluster using workload identity federation.
+	cluster-aks   Registers an Azure AKS cluster using workload identity federation.
 
 Options:
 	-h --help      Show this screen.
@@ -68,6 +71,12 @@ Description:
 	switch command {
 	case "cluster":
 		return onboard.RegisterCluster(ctx, arguments, logger)
+	case "cluster-eks":
+		return onboard.RegisterClusterEKS(ctx, arguments, logger)
+	case "cluster-gke":
+		return onboard.RegisterClusterGKE(ctx, arguments, logger)
+	case "cluster-aks":
+		return onboard.RegisterClusterAKS(ctx, arguments, logger)
 	default:
 		//nolint: forbidigo // print doc
 		fmt.Println(doc)


### PR DESCRIPTION
register cluster accumulated 20 flags after the workload identity addition, making the command hard to use and document.
This PR splits the cloud-provider-specific paths into dedicated subcommands so each command carries only the flags it needs.

New subcommands:

- register cluster-eks — EKS via IRSA (--endpoint, --eks-cluster-name, --role-arn, --region, --ca-file)
- register cluster-gke — GKE via workload identity federation (--endpoint, --project-id, --gke-cluster-name, --location, --ca-file)
- register cluster-aks — AKS via workload identity federation (--endpoint, --tenant-id, --client-id, --subscription-id, --resource-group, --aks-cluster-name, --ca-file)